### PR TITLE
fix incorrectly hardcoded label when calculating volume

### DIFF
--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -37,7 +37,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     self.matrixCoordinates = numpy.where(self.maskArray != 0)
 
     # Volume and Surface Area are pre-calculated
-    self.Volume = self.lssif.GetPhysicalSize(1)
+    self.Volume = self.lssif.GetPhysicalSize(self.label)
     self.SurfaceArea = self._calculateSurfaceArea()
 
   def _calculateSurfaceArea(self):


### PR DESCRIPTION
This fixes an incorrectly hardcoded label that causes the calculation of features for labels != 1 to fail.

@JoostJM, unfortunately, I can't mention the whole team as suggested in the contribution guidelines. 