### PR TITLE
Revert required numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.10.0
+numpy>=1.9.2
 SimpleITK>=0.9.1
 nose-parameterized>=0.5.0
 tqdm>=4.7.1


### PR DESCRIPTION
For integration with slicer, revert minimum required numpy version to 1.9.2. This is the version of numpy currently distributed with slicer, so if pyradiomics is installed to slicer as part of an extension module, it does not cause the installed numpy for slicer to be changed.