### PR TITLE
Add CLI scripts to setup

### DIFF
--- a/bin/Notebooks/helloFeatureClass.ipynb
+++ b/bin/Notebooks/helloFeatureClass.ipynb
@@ -39,6 +39,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
+    "\n",
+    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (os.path.sep + \"..\") and then move into the data folders (os.path.sep + \"data\").\n",
+    "\n",
+    "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {

--- a/bin/Notebooks/helloFeatureClass.ipynb
+++ b/bin/Notebooks/helloFeatureClass.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
     "\n",
-    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (os.path.sep + \"..\") and then move into the data folders (os.path.sep + \"data\").\n",
+    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (\"..\") and then move into the data folders (\"data\").\n",
     "\n",
     "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
    ]
@@ -58,9 +58,9 @@
    "outputs": [],
    "source": [
     "testCase = 'brain1'\n",
-    "dataDir = os.path.abspath(radiomics.__path__[0] + os.path.sep + \"..\" + os.path.sep + \"data\")\n",
-    "imageName = str(dataDir + os.path.sep + testCase +'_image.nrrd')\n",
-    "maskName = str(dataDir + os.path.sep + testCase + '_label.nrrd')\n",
+    "dataDir = os.path.join(os.path.abspath(\"\"), \"..\", \"..\", \"data\")\n",
+    "imageName = os.path.join(dataDir, testCase + '_image.nrrd')\n",
+    "maskName = os.path.join(dataDir, testCase + '_label.nrrd')\n",
     "\n",
     "if not os.path.exists(imageName):\n",
     "  print 'Error: problem finding input image', imageName\n",
@@ -432,7 +432,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "calculate GLCM: 100%|██████████████████████████████████████████████████████████████████| 33/33 [00:00<00:00, 51.64it/s]\n"
+      "calculate GLCM: 100%|██████████████████████████████████████████████████████████████████| 33/33 [00:01<00:00, 29.62it/s]\n"
      ]
     }
    ],
@@ -1345,23 +1345,53 @@
       "   wavelet-HLH_TotalEnergy : 65648014380.2\n",
       "   wavelet-HLH_Maximum : 54.031233446\n",
       "   wavelet-HLH_RootMeanSquared : 1999.96008551\n",
-      "   wavelet-HLH_90Percentile"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "I/O operation on closed file",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-24-5d2bff7ed0e2>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      3\u001b[0m   \u001b[1;32mfor\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mval\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mfeatures\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0miteritems\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mwaveletFeatureName\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;34m'wavelet-%s_%s'\u001b[0m \u001b[1;33m%\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdecompositionName\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 5\u001b[1;33m     \u001b[1;32mprint\u001b[0m \u001b[1;34m'  '\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwaveletFeatureName\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m':'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mval\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32mc:\\python27\\lib\\site-packages\\colorama\\ansitowin32.pyc\u001b[0m in \u001b[0;36mwrite\u001b[1;34m(self, text)\u001b[0m\n\u001b[0;32m     38\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     39\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 40\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__convertor\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     41\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     42\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mc:\\python27\\lib\\site-packages\\colorama\\ansitowin32.pyc\u001b[0m in \u001b[0;36mwrite\u001b[1;34m(self, text)\u001b[0m\n\u001b[0;32m    139\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    140\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstrip\u001b[0m \u001b[1;32mor\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mconvert\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 141\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite_and_convert\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    142\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    143\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrapped\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mc:\\python27\\lib\\site-packages\\colorama\\ansitowin32.pyc\u001b[0m in \u001b[0;36mwrite_and_convert\u001b[1;34m(self, text)\u001b[0m\n\u001b[0;32m    167\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mconvert_ansi\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mmatch\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgroups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    168\u001b[0m             \u001b[0mcursor\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mend\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 169\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite_plain_text\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcursor\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    170\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    171\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mc:\\python27\\lib\\site-packages\\colorama\\ansitowin32.pyc\u001b[0m in \u001b[0;36mwrite_plain_text\u001b[1;34m(self, text, start, end)\u001b[0m\n\u001b[0;32m    172\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwrite_plain_text\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtext\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mstart\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mend\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    173\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mstart\u001b[0m \u001b[1;33m<\u001b[0m \u001b[0mend\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 174\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrapped\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtext\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mstart\u001b[0m\u001b[1;33m:\u001b[0m\u001b[0mend\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    175\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrapped\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mflush\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    176\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mc:\\python27\\lib\\site-packages\\ipykernel\\iostream.pyc\u001b[0m in \u001b[0;36mwrite\u001b[1;34m(self, string)\u001b[0m\n\u001b[0;32m    315\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    316\u001b[0m             \u001b[0mis_child\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_is_master_process\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 317\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_buffer\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mstring\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    318\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mis_child\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    319\u001b[0m                 \u001b[1;31m# newlines imply flush in subprocesses\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mValueError\u001b[0m: I/O operation on closed file"
+      "   wavelet-HLH_90Percentile : 10.5580383627\n",
+      "   wavelet-HLH_Minimum : -59.7402845962\n",
+      "   wavelet-HLH_Entropy : 1.09951676451\n",
+      "   wavelet-HLH_StandardDeviation : 9.02836267104\n",
+      "   wavelet-HLH_Range : 113.771518042\n",
+      "   wavelet-HLH_Variance : 81.5113325198\n",
+      "   wavelet-HLH_10Percentile : -10.5831673374\n",
+      "   wavelet-HLH_Kurtosis : 6.47263183683\n",
+      "   wavelet-HLH_Mean : -0.0602928335869\n",
+      "   wavelet-HHH_InterquartileRange : 10.9326520923\n",
+      "   wavelet-HHH_Skewness : -0.161302587938\n",
+      "   wavelet-HHH_Uniformity : 0.486414452921\n",
+      "   wavelet-HHH_MeanAbsoluteDeviation : 6.88788741453\n",
+      "   wavelet-HHH_Energy : 16547974728.9\n",
+      "   wavelet-HHH_RobustMeanAbsoluteDeviation : 4.54697240555\n",
+      "   wavelet-HHH_Median : 0.0513263224352\n",
+      "   wavelet-HHH_TotalEnergy : 65650534507.8\n",
+      "   wavelet-HHH_Maximum : 59.9134724023\n",
+      "   wavelet-HHH_RootMeanSquared : 1999.99847286\n",
+      "   wavelet-HHH_90Percentile : 10.735432567\n",
+      "   wavelet-HHH_Minimum : -58.0273629729\n",
+      "   wavelet-HHH_Entropy : 1.11204797433\n",
+      "   wavelet-HHH_StandardDeviation : 9.19944859408\n",
+      "   wavelet-HHH_Range : 117.940835375\n",
+      "   wavelet-HHH_Variance : 84.6298544352\n",
+      "   wavelet-HHH_10Percentile : -10.6879329892\n",
+      "   wavelet-HHH_Kurtosis : 6.35651924152\n",
+      "   wavelet-HHH_Mean : -0.0226847341909\n",
+      "   wavelet-HHL_InterquartileRange : 11.4885048182\n",
+      "   wavelet-HHL_Skewness : 0.00173347436935\n",
+      "   wavelet-HHL_Uniformity : 0.482438705425\n",
+      "   wavelet-HHL_MeanAbsoluteDeviation : 7.09468688619\n",
+      "   wavelet-HHL_Energy : 16548297953.4\n",
+      "   wavelet-HHL_RobustMeanAbsoluteDeviation : 4.73465210477\n",
+      "   wavelet-HHL_Median : 0.0731800928294\n",
+      "   wavelet-HHL_TotalEnergy : 65651816831.6\n",
+      "   wavelet-HHL_Maximum : 52.750446198\n",
+      "   wavelet-HHL_RootMeanSquared : 2000.01800532\n",
+      "   wavelet-HHL_90Percentile : 11.1168222752\n",
+      "   wavelet-HHL_Minimum : -52.3423184536\n",
+      "   wavelet-HHL_Entropy : 1.13367844225\n",
+      "   wavelet-HHL_StandardDeviation : 9.38156375064\n",
+      "   wavelet-HHL_Range : 105.092764652\n",
+      "   wavelet-HHL_Variance : 88.0137384072\n",
+      "   wavelet-HHL_10Percentile : -11.1708244039\n",
+      "   wavelet-HHL_Kurtosis : 5.24887979579\n",
+      "   wavelet-HHL_Mean : -0.00399803756091\n"
      ]
     }
    ],

--- a/bin/Notebooks/helloRadiomics.ipynb
+++ b/bin/Notebooks/helloRadiomics.ipynb
@@ -78,6 +78,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
+    "\n",
+    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (os.path.sep + \"..\") and then move into the data folders (os.path.sep + \"data\").\n",
+    "\n",
+    "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -86,7 +97,7 @@
    "outputs": [],
    "source": [
     "testCase = 'brain1'\n",
-    "dataDir = os.path.abspath(radiomics.__path__[0] + os.path.sep + \"..\" + os.path.sep + \"data\")\n",
+    "dataDir = os.path.abspath(\"\") + os.path.sep + \"..\" + os.path.sep + \"..\" + os.path.sep + \"data\"\n",
     "imageName = str(dataDir + os.path.sep + testCase +'_image.nrrd')\n",
     "maskName = str(dataDir + os.path.sep + testCase + '_label.nrrd')\n",
     "\n",
@@ -421,7 +432,7 @@
       "Computed general_info_ImageSpacing: (0.7812499999999999; 0.7812499999999999; 6.499999999999998)\n",
       "Computed general_info_InputImages: {'original': {}}\n",
       "Computed general_info_MaskHash: 9dc2c3137b31fd872997d92c9a92d5178126d9d3\n",
-      "Computed general_info_Version: 0.post402.dev0+gb4e35ec\n",
+      "Computed general_info_Version: v1.0.post11.dev0+g610dffc\n",
       "Computed general_info_VolumeNum: 2\n",
       "Computed general_info_VoxelNum: 4137\n",
       "Computed original_firstorder_InterquartileRange: 253.0\n",
@@ -452,6 +463,17 @@
     "\n",
     "for featureName in featureVector.keys():\n",
     "  print \"Computed %s: %s\" % (featureName, featureVector[featureName])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
    ]
   }
  ],

--- a/bin/Notebooks/helloRadiomics.ipynb
+++ b/bin/Notebooks/helloRadiomics.ipynb
@@ -83,7 +83,7 @@
    "source": [
     "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
     "\n",
-    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (os.path.sep + \"..\") and then move into the data folders (os.path.sep + \"data\").\n",
+    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (\"..\") and then move into the data folders (\"data\").\n",
     "\n",
     "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
    ]
@@ -97,9 +97,9 @@
    "outputs": [],
    "source": [
     "testCase = 'brain1'\n",
-    "dataDir = os.path.abspath(\"\") + os.path.sep + \"..\" + os.path.sep + \"..\" + os.path.sep + \"data\"\n",
-    "imageName = str(dataDir + os.path.sep + testCase +'_image.nrrd')\n",
-    "maskName = str(dataDir + os.path.sep + testCase + '_label.nrrd')\n",
+    "dataDir = os.path.join(os.path.abspath(\"\"), \"..\", \"..\", \"data\")\n",
+    "imageName = os.path.join(dataDir, testCase + '_image.nrrd')\n",
+    "maskName = os.path.join(dataDir, testCase + '_label.nrrd')\n",
     "\n",
     "if not os.path.exists(imageName):\n",
     "  print 'Error: problem finding input image', imageName\n",
@@ -464,17 +464,6 @@
     "for featureName in featureVector.keys():\n",
     "  print \"Computed %s: %s\" % (featureName, featureVector[featureName])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    ""
-   ]
   }
  ],
  "metadata": {
@@ -486,7 +475,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/bin/helloFeatureClass.py
+++ b/bin/helloFeatureClass.py
@@ -6,11 +6,10 @@ from radiomics import firstorder, glcm, imageoperations, shape, glrlm, glszm
 # testBinWidth = 25 this is the default bin size
 # testResampledPixelSpacing = [3,3,3] no resampling for now.
 
-dataDir = os.path.abspath("") + os.path.sep + ".." + os.path.sep + "data"  # assumes this file in in pyradiomics/bin
-# imageName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume.nrrd')
-# maskName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume-label.nrrd')
-imageName = str(dataDir + os.path.sep + 'breast1_image.nrrd')
-maskName = str(dataDir + os.path.sep + 'breast1_label.nrrd')
+testCase = 'brain1'
+dataDir = os.path.join(os.path.abspath(""), "..", "data")
+imageName = os.path.join(dataDir, testCase + '_image.nrrd')
+maskName = os.path.join(dataDir, testCase + '_label.nrrd')
 
 if not os.path.exists(imageName):
   print 'Error: problem finding input image', imageName

--- a/bin/helloFeatureClass.py
+++ b/bin/helloFeatureClass.py
@@ -4,9 +4,9 @@ import numpy
 from radiomics import firstorder, glcm, imageoperations, shape, glrlm, glszm
 
 # testBinWidth = 25 this is the default bin size
-# testResampledPixelSpacing = (3,3,3) no resampling for now.
+# testResampledPixelSpacing = [3,3,3] no resampling for now.
 
-dataDir = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + ".." + os.path.sep + "data"
+dataDir = os.path.abspath("") + os.path.sep + ".." + os.path.sep + "data"  # assumes this file in in pyradiomics/bin
 # imageName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume.nrrd')
 # maskName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume-label.nrrd')
 imageName = str(dataDir + os.path.sep + 'breast1_image.nrrd')

--- a/bin/helloRadiomics.py
+++ b/bin/helloRadiomics.py
@@ -4,11 +4,10 @@ import SimpleITK as sitk
 from radiomics import featureextractor
 import radiomics
 
-dataDir = os.path.abspath("") + os.path.sep + ".." + os.path.sep + "data"  # assumes this file in in pyradiomics/bin
-# imageName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume.nrrd')
-# maskName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume-label.nrrd')
-imageName = str(dataDir + os.path.sep + 'brain1_image.nrrd')
-maskName = str(dataDir + os.path.sep + 'brain1_label.nrrd')
+testCase = 'brain1'
+dataDir = os.path.join(os.path.abspath(""), "..", "data")
+imageName = os.path.join(dataDir, testCase + '_image.nrrd')
+maskName = os.path.join(dataDir, testCase + '_label.nrrd')
 
 if not os.path.exists(imageName):
   print 'Error: problem finding input image', imageName

--- a/bin/helloRadiomics.py
+++ b/bin/helloRadiomics.py
@@ -4,7 +4,7 @@ import SimpleITK as sitk
 from radiomics import featureextractor
 import radiomics
 
-dataDir = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + ".." + os.path.sep + "data"
+dataDir = os.path.abspath("") + os.path.sep + ".." + os.path.sep + "data"  # assumes this file in in pyradiomics/bin
 # imageName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume.nrrd')
 # maskName = str(dataDir + os.path.sep + 'prostate_phantom_subvolume-label.nrrd')
 imageName = str(dataDir + os.path.sep + 'brain1_image.nrrd')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,15 +6,95 @@ Usage
 Example
 -------
 
-* Run the helloRadiomics example, using sample data provided in ``pyradiomics/data``:
+* PyRadiomics example code and data is available in the `Github repository <https://github.com/Radiomics/pyradiomics>`_
 
-  * ``python bin/helloRadiomics.py``
+* The sample sample data is provided in ``pyradiomics/data``.
+
+* Use jupyter to run the helloRadiomics example, located in ``pyradiomics/bin/Notebooks``.
+
+* If jupyter is not installed, run the python script alternative (``pyradiomics/bin/helloRadiomics.py``):
+
+  * ``python helloRadiomics.py``
+
+----------------
+Command Line Use
+----------------
+
+* PyRadiomics has 2 commandline scripts, ``pyradiomics`` is for single image feature extraction and ``pyradiomicsbatch``
+  is for feature extraction from a batch of images and segmentations.
+
+* Both scripts can be run directly from a command line window, anywhere in your system.
+
+* To extract features from a single image and segmentation run::
+
+    pyradiomics <path/to/image> <path/to/segmentation>
+
+* To extract features from a batch run::
+
+    pyradiomicsbatch <path/to/input> <path/to/output>
+
+* The input file for batch processing is a CSV file where each row represents one combination of an image and a
+  segmentation and contains 5 elements: 1) patient ID, 2) sequence name (image identifier), 3) reader (segmentation
+  identifier), 4) path/to/image, 5) path/to/mask.
+
+* For more information on passing parameter files, setting up logging and controlling output format, run::
+
+    pyradiomics -h
+    pyradiomicsbatch -h
+
 
 ---------------
 Interactive Use
 ---------------
 
-* Add pyradiomics to the environment variable PYTHONPATH:
+* (LINUX) Add pyradiomics to the environment variable PYTHONPATH:
+
+  *  ``setenv PYTHONPATH /path/to/pyradiomics/radiomics``
+
+* Start the python interactive session:
+
+  * ``python``
+
+* Import the necessary classes::
+
+     from radiomics import featureextractor
+     import sys, os
+
+* Set up a pyradiomics directory variable::
+
+    dataDir = '/path/to/pyradiomics'
+
+* You will find sample data files brain1_image.nrrd and brain1_label.nrrd in that directory.
+
+* Store the path of your image and mask in two variables::
+
+    imageName = os.path.join(dataDir, "data", 'brain1_image.nrrd')
+    maskName = os.path.join(dataDir, "data",  'brain1_label.nrrd')
+
+* Also store the path to the file containing the extraction settings::
+
+    params = os.path.join(dataDir, "bin", "Params.yaml")
+
+* Instantiate the feature extractor class with the parameter file::
+
+    extractor = featureextractor.RadiomicsFeaturesExtractor(params)
+
+* Calculate the features::
+
+    result = extractor.execute(imageName, maskName)
+    for key, val in result.iteritems():
+      print "\t%s: %s" %(key, val)
+
+* See the :ref:`feature extractor class<radiomics-featureextractor-label>` for more information on using this core class.
+
+------------------------------
+Using feature classes directly
+------------------------------
+
+* This represents an example where feature classes are used directly, circumventing checks and preprocessing done by
+  the radiomics feature extractor class, and is not intended as standard use example.
+
+* (LINUX) Add pyradiomics to the environment variable PYTHONPATH:
 
   *  ``setenv PYTHONPATH /path/to/pyradiomics/radiomics``
 
@@ -46,6 +126,6 @@ Interactive Use
      firstOrderFeatures = firstorder.RadiomicsFirstOrder(image,mask)
      firstOrderFeatures.calculateFeatures()
      for (key,val) in firstOrderFeatures.featureValues.iteritems():
-       print '  ',key,':',val
+       print "\t%s: %s" % (key, val)
 
 * See the :ref:`radomics package<radiomics-firstorder-label>` for more features that you can calculate.

--- a/radiomics/scripts/commandline.py
+++ b/radiomics/scripts/commandline.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import sys
 import os.path

--- a/radiomics/scripts/commandline.py
+++ b/radiomics/scripts/commandline.py
@@ -15,21 +15,21 @@ parser.add_argument('image', metavar='Image',
                     help='Features are extracted from the Region Of Interest (ROI) in the image')
 parser.add_argument('mask', metavar='Mask', help='Mask identifying the ROI in the Image')
 
-parser.add_argument('--out', '-o', metavar='FILE', nargs='?', type=argparse.FileType('a'), default=sys.stdout,
+parser.add_argument('--out', '-o', metavar='FILE', nargs='?', type=argparse.FileType('w'), default=sys.stdout,
                     help='File to append output to')
 parser.add_argument('--format', '-f', choices=['txt', 'csv', 'json'], default='txt',
                     help='Format for the output. '
                          'Default is "txt": one feature per line in format "name:value". For "csv": one row of feature '
                          'names, followed by one row of feature values. For "json": Features are written in a JSON '
                          'format dictionary "{name:value}"')
-parser.add_argument('--param', '-p', metavar='FILE', nargs=1, default=None,
+parser.add_argument('--param', '-p', metavar='FILE', nargs=1, type=argparse.FileType('r'), default=None,
                     help='Parameter file containing the settings to be used in extraction')
 parser.add_argument('--label', '-l', metavar='N', nargs=1, default=None, type=int,
                     help='Value of label in mask to use for feature extraction')
 parser.add_argument('--logging-level', metavar='LEVEL',
                     choices=['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                     default='WARNING', help='Set capture level for logging')
-parser.add_argument('--log-file', metavar='FILE', nargs='?', type=argparse.FileType('a'), default=sys.stderr,
+parser.add_argument('--log-file', metavar='FILE', nargs='?', type=argparse.FileType('w'), default=sys.stderr,
                     help='File to append logger output to')
 
 

--- a/radiomics/scripts/commandlinebatch.py
+++ b/radiomics/scripts/commandlinebatch.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import sys
 import os.path
@@ -73,6 +75,7 @@ def main():
   # Extract features
   logging.info('Extracting features with kwarg settings: %s', str(extractor.kwargs))
 
+  headers = False
   for idx, entry in enumerate(flists, start=1):
 
     logging.info("(%d/%d) Processing Patient: %s, Study: %s, Reader: %s", idx, len(flists), entry[0], entry[1],
@@ -94,7 +97,9 @@ def main():
 
         if args.format == 'csv':
           writer = csv.writer(args.outFile, lineterminator='\n')
-          if idx == 1: writer.writerow(featureVector.keys())
+          if not headers:
+            writer.writerow(featureVector.keys())
+            headers = True
           writer.writerow(featureVector.values())
         elif args.format == 'json':
           json.dump(featureVector, args.out)

--- a/radiomics/scripts/commandlinebatch.py
+++ b/radiomics/scripts/commandlinebatch.py
@@ -17,17 +17,17 @@ parser.add_argument('inFile', metavar='In', type=argparse.FileType('r'),
                          '(5) Mask location')
 parser.add_argument('outFile', metavar='Out', type=argparse.FileType('w'), help='File to write results to')
 parser.add_argument('--format', '-f', choices=['csv', 'json'], default='csv', help='Format for the output. '
-                                                                                   'Default is "csv": one row of feature names, followed by one row of feature values for each '
-                                                                                   'image-mask combination. For "json": Features are written in a JSON format dictionary '
-                                                                                   '"{name:value}", one line per image-mask combination')
-parser.add_argument('--param', '-p', metavar='FILE', nargs=1, default=None,
+                    'Default is "csv": one row of feature names, followed by one row of feature values for each '
+                    'image-mask combination. For "json": Features are written in a JSON format dictionary '
+                    '"{name:value}", one line per image-mask combination')
+parser.add_argument('--param', '-p', metavar='FILE', nargs=1, type=argparse.FileType('r'), default=None,
                     help='Parameter file containing the settings to be used in extraction')
 parser.add_argument('--label', '-l', metavar='N', nargs=1, default=None, type=int,
                     help='Value of label in mask to use for feature extraction')
 parser.add_argument('--logging-level', metavar='LEVEL',
                     choices=['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                     default='WARNING', help='Set capture level for logging')
-parser.add_argument('--log-file', metavar='FILE', nargs='?', type=argparse.FileType('a'), default=sys.stderr,
+parser.add_argument('--log-file', metavar='FILE', nargs='?', type=argparse.FileType('w'), default=sys.stderr,
                     help='File to append logger output to')
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,11 @@ with open('requirements.txt', 'r') as fp:
 setup(name='pyradiomics',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
-      packages=['radiomics'],
+      packages=['radiomics', 'radiomics.scripts'],
+      entry_points={'console_scripts': ['pyradiomics=radiomics.scripts.commandline:main',
+                                        'pyradiomicsbatch=radiomics.scripts.commandlinebatch:main']},
       data_files=[
-        ('data', ['data/paramSchema.yaml', 'data/schemaFuncs.py', 'data/brain1_image.nrrd', 'data/brain1_label.nrrd'])],
+        ('data', ['data/paramSchema.yaml', 'data/schemaFuncs.py'])],
       description='Radiomics features library for python',
       url='http://github.com/Radiomics/pyradiomics',
       author='pyradiomics community',


### PR DESCRIPTION
Rename the scripts to pyradiomics and pyradiomicsbatch (easy to remeber, but unique to package, for use in the commandline). Additionally, move them to separate folder in the package, and add them to the setup script so the CLI gets distributed with the installation, not just the git repo.
Additionally, add the use of these scripts to the `Usage` section of the documentation and adapt this section further to represent the more standard use of the toolbox, including interactive extraction using the `featureextractor` module.

Finally, adapt the examples in the bin folder to make use of the example data stored in the repository, this removes the need to install the example data when pyradiomics is installed.

cc @Radiomics/developers 