### PR TITLE
Add links to the instruction video

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Joost J.M. van Griethuysen et al, “Computational Radiomics System to Decode th
 See also the [requirements file](requirements.txt).
 
 ### WIP
- - Implementation of this package as an extension to [3D Slicer](https://github.com/Slicer/Slicer)
+ - Implementation of this package as an [extension](https://github.com/Radiomics/SlicerRadiomics) to [3D Slicer](slicer.org)
  - Enhancing performance by implementation of C for computationally expensive code
 
 ### License
@@ -106,6 +106,14 @@ This package is covered by the [3D Slicer License](LICENSE.txt).
 <sup>4</sup>GROW-School for Oncology and Developmental Biology, Maastricht University Medical Center, Maastricht, The Netherlands,
 <sup>5</sup>Kitware,
 <sup>6</sup>Isomics
+
+### Contact
+
+We are happy to help you with any questions. Please contact us by sending an email to 
+[info@radiomics.io](mailto:info@radiomics.io).
+
+We welcome contributions to PyRadiomics. Please read the [contributing guidelines](CONTRIBUTING.md) on how to contribute
+to PyRadiomics.
 
 ### General references
 

--- a/README.md
+++ b/README.md
@@ -109,19 +109,8 @@ This package is covered by the [3D Slicer License](LICENSE.txt).
 
 ### Contact
 
-We are happy to help you with any questions. Please contact us by sending an email to 
-[info@radiomics.io](mailto:info@radiomics.io).
+We are happy to help you with any questions. Please contact us on the [pyradiomics email list](https://groups.google.com/forum/#!forum/pyradiomics).
 
 We welcome contributions to PyRadiomics. Please read the [contributing guidelines](CONTRIBUTING.md) on how to contribute
 to PyRadiomics.
-
-### General references
-
-- HJWL Aerts, ER Velazquez, RTH Leijenaar, et al., "Decoding tumour phenotype by noninvasive imaging using a 
-  quantitative radiomics approach", vol. 5, Nat Communication, 2014. 
-  Available [here](http://www.nature.com/ncomms/2014/140603/ncomms5006/full/ncomms5006.html).
-  Specifically, the formulation of the individual feature calculation is covered in this 
-  [supplement](http://www.nature.com/ncomms/2014/140603/ncomms5006/extref/ncomms5006-s1.pdf).
-- Zwanenburg A, Leger S, Vallières M, Löck S., "Image biomarker standardisation initiative - feature definitions", 
-  arXiv:161207003. 2016. Available [here](http://arxiv.org/abs/1612.07003).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Alternatively, you can generate the documentation by checking out the master bra
 
 The documentation can then be viewed in a browser by opening `PACKAGE_ROOT\build\sphinx\html\index.html`. 
 
+Furthermore, an instruction video is available [here](http://radiomics.io/pyradiomics.html).
+
 ### Installation
 
 To install this package run the following commands from the root directory:

--- a/bin/Notebooks/PyRadiomics Example.ipynb
+++ b/bin/Notebooks/PyRadiomics Example.ipynb
@@ -1,0 +1,505 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example of using the PyRadiomics toolbox in Python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, import some built-in Python modules needed to get our testing data.\n",
+    "Second, import the toolbox, only the `featureextractor` is needed, this module handles the interaction with other parts of the toolbox."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os  # needed navigate the system to get the input data\n",
+    "\n",
+    "from radiomics import featureextractor  # This module is used for interaction with pyradiomics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we can extract features, we need to get the input data, define the parameters for the extraction and instantiate the class contained within `featureextractor`.\n",
+    "\n",
+    "In the next cell we get our testing data, this consists of an image and corresponding segmentation. This is also available from the PyRadiomics repository and is stored in `\\pyradiomics\\data`, whereas this file (and therefore, the current directory) is `\\pyradiomics\\bin\\Notebooks`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataDir, relative path: R:\\GitRepos\\pyradiomics\\bin\\Notebooks\\..\\..\\data\n",
+      "dataDir, absolute path: R:\\GitRepos\\pyradiomics\\data\n",
+      "Parameter file, absolute path: R:\\GitRepos\\pyradiomics\\bin\\Params.yaml\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define the testcase name\n",
+    "testCase = 'brain1'\n",
+    "\n",
+    "# Get the relative path to pyradiomics\\data\n",
+    "# os.cwd() returns the current working directory\n",
+    "# \"..\" points to the parent directory: \\pyradiomics\\bin\\Notebooks\\..\\ is equal to \\pyradiomics\\bin\\\n",
+    "# Move up 2 directories (i.e. go to \\pyradiomics\\) and then move into \\pyradiomics\\data\n",
+    "dataDir = os.path.join(os.getcwd(), \"..\", \"..\", \"data\")\n",
+    "print \"dataDir, relative path:\", dataDir\n",
+    "print \"dataDir, absolute path:\", os.path.abspath(dataDir)\n",
+    "\n",
+    "# Store the file paths of our testing image and label map into two variables\n",
+    "imagePath = os.path.join(dataDir, testCase + \"_image.nrrd\")\n",
+    "labelPath = os.path.join(dataDir, testCase + \"_label.nrrd\")\n",
+    "\n",
+    "# Additonally, store the location of the example parameter file, stored in \\pyradiomics\\bin\n",
+    "paramPath = os.path.join(os.getcwd(), \"..\", \"Params.yaml\")\n",
+    "print \"Parameter file, absolute path:\", os.path.abspath(paramPath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Instantiating the extractor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have our input, we need to define the parameters and instantiate the extractor.\n",
+    "For this there are three possibilities:\n",
+    "\n",
+    "1. Use defaults, don't define custom settings\n",
+    "\n",
+    "2. Define parameters in a dictionary, control filters and features after initialisation\n",
+    "\n",
+    "3. Use a parameter file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Method 1, use defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extraction parameters:\n",
+      "\t{'resampledPixelSpacing': None, 'interpolator': 3, 'verbose': False, 'padDistance': 5, 'label': 1}\n",
+      "Enabled filters:\n",
+      "\t{'Original': {}}\n",
+      "Enabled features:\n",
+      "\t{'firstorder': [], 'glcm': [], 'shape': [], 'glrlm': [], 'glszm': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Instantiate the extractor\n",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor()\n",
+    "\n",
+    "print \"Extraction parameters:\\n\\t\", extractor.kwargs\n",
+    "print \"Enabled filters:\\n\\t\", extractor.inputImages\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Method 2, hard-coded settings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extraction parameters:\n",
+      "\t{'verbose': True, 'binWidth': 20, 'label': 1, 'interpolator': 3, 'resampledPixelSpacing': None, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
+      "Enabled filters:\n",
+      "\t{'Original': {}}\n",
+      "Enabled features:\n",
+      "\t{'firstorder': [], 'glcm': [], 'shape': [], 'glrlm': [], 'glszm': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# First define the parameters\n",
+    "params = {}\n",
+    "params['binWidth'] = 20\n",
+    "params['sigma'] = [1, 2, 3]\n",
+    "params['verbose'] = True\n",
+    "\n",
+    "# Instantiate the extractor\n",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor(**params)  # ** 'unpacks' the dictionary in the function call\n",
+    "\n",
+    "print \"Extraction parameters:\\n\\t\", extractor.kwargs\n",
+    "print \"Enabled filters:\\n\\t\", extractor.inputImages  # Still the default settings\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures  # Still the default settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extraction parameters:\n",
+      "\t{'verbose': True, 'binWidth': 20, 'label': 1, 'interpolator': 3, 'resampledPixelSpacing': None, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
+      "Enabled filters:\n",
+      "\t{'Original': {}}\n",
+      "Enabled features:\n",
+      "\t{'firstorder': [], 'glcm': [], 'shape': [], 'glrlm': [], 'glszm': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This cell is equivalent to the previous cell\n",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor(binWidth=20, sigma=[1, 2, 3], verbose=True)  # Equivalent of code above\n",
+    "\n",
+    "print \"Extraction parameters:\\n\\t\", extractor.kwargs\n",
+    "print \"Enabled filters:\\n\\t\", extractor.inputImages  # Still the default settings\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures  # Still the default settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Enabled filters:\n",
+      "\t{'Original': {}, 'LoG': {}}\n",
+      "\n",
+      "Enabled features:\n",
+      "\t{'firstorder': []}\n",
+      "\n",
+      "Enabled features:\n",
+      "\t{'firstorder': [], 'glcm': ['Autocorrelation', 'Homogeneity1', 'SumSquares']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Enable a filter (in addition to the 'Original' filter already enabled)\n",
+    "extractor.enableInputImageByName('LoG')\n",
+    "print \"\"\n",
+    "print \"Enabled filters:\\n\\t\", extractor.inputImages\n",
+    "\n",
+    "# Disable all feature classes, save firstorder\n",
+    "extractor.disableAllFeatures()\n",
+    "extractor.enableFeatureClassByName('firstorder')\n",
+    "print \"\"\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures\n",
+    "\n",
+    "# Specify some additional features in the GLCM feature class\n",
+    "extractor.enableFeaturesByName(glcm=['Autocorrelation', 'Homogeneity1', 'SumSquares'])\n",
+    "print \"\"\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Method 3, using a parameter file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extraction parameters:\n",
+      "\t{'verbose': True, 'binWidth': 25, 'label': 1, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'weightingNorm': None, 'padDistance': 5}\n",
+      "Enabled filters:\n",
+      "\t{'Original': {}}\n",
+      "Enabled features:\n",
+      "\t{'firstorder': [], 'glcm': None, 'shape': None, 'glrlm': None, 'glszm': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Instantiate the extractor\n",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor(paramPath)\n",
+    "\n",
+    "print \"Extraction parameters:\\n\\t\", extractor.kwargs\n",
+    "print \"Enabled filters:\\n\\t\", extractor.inputImages\n",
+    "print \"Enabled features:\\n\\t\", extractor.enabledFeatures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Extract features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have our extractor set up with the correct parameters, we can start extracting features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t\tComputing shape\n",
+      "\t\tComputing firstorder\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "calculate GLCM: 100%|██████████████████████████████████████████████████████████████████| 33/33 [00:00<00:00, 38.73it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t\tComputing glcm\n",
+      "\t\tComputing glrlm\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "calculate GLSZM: 100%|█████████████████████████████████████████████████████████████████| 33/33 [00:00<00:00, 56.90it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t\tComputing glszm\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = extractor.execute(imagePath, labelPath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result type: <class 'collections.OrderedDict'>\n",
+      "\n",
+      "Calculated features\n",
+      "\tgeneral_info_BoundingBox : (162; 84; 11; 47; 70; 7)\n",
+      "\tgeneral_info_GeneralSettings : {'verbose': True; 'binWidth': 25; 'label': 1; 'interpolator': 'sitkBSpline'; 'resampledPixelSpacing': None; 'weightingNorm': None; 'padDistance': 5}\n",
+      "\tgeneral_info_ImageHash : 5c9ce3ca174f0f8324aa4d277e0fef82dc5ac566\n",
+      "\tgeneral_info_ImageSpacing : (0.7812499999999999; 0.7812499999999999; 6.499999999999998)\n",
+      "\tgeneral_info_InputImages : {'Original': {}}\n",
+      "\tgeneral_info_MaskHash : 9dc2c3137b31fd872997d92c9a92d5178126d9d3\n",
+      "\tgeneral_info_Version : v1.0.post25.dev0+g00e9e5d\n",
+      "\tgeneral_info_VolumeNum : 2\n",
+      "\tgeneral_info_VoxelNum : 4137\n",
+      "\toriginal_shape_Maximum3DDiameter : 65.5366145873\n",
+      "\toriginal_shape_Compactness2 : 0.114127701901\n",
+      "\toriginal_shape_Maximum2DDiameterSlice : 47.2187913633\n",
+      "\toriginal_shape_Sphericity : 0.485061744222\n",
+      "\toriginal_shape_Compactness1 : 26.7546787215\n",
+      "\toriginal_shape_Elongation : 1.7789885567\n",
+      "\toriginal_shape_SurfaceVolumeRatio : 0.392308261863\n",
+      "\toriginal_shape_Volume : 16412.6586914\n",
+      "\toriginal_shape_Flatness : 1.21918505897\n",
+      "\toriginal_shape_SphericalDisproportion : 2.06159321347\n",
+      "\toriginal_shape_Roundness : 0.61469066615\n",
+      "\toriginal_shape_SurfaceArea : 6438.82160378\n",
+      "\toriginal_shape_Maximum2DDiameterColumn : 44.5487904052\n",
+      "\toriginal_shape_Maximum2DDiameterRow : 61.5801767135\n",
+      "\toriginal_firstorder_InterquartileRange : 253.0\n",
+      "\toriginal_firstorder_Skewness : 0.275650859086\n",
+      "\toriginal_firstorder_Uniformity : 0.0451569635559\n",
+      "\toriginal_firstorder_MeanAbsoluteDeviation : 133.447261953\n",
+      "\toriginal_firstorder_Energy : 33122817481.0\n",
+      "\toriginal_firstorder_RobustMeanAbsoluteDeviation : 103.00138343\n",
+      "\toriginal_firstorder_Median : 812.0\n",
+      "\toriginal_firstorder_TotalEnergy : 131407662126.0\n",
+      "\toriginal_firstorder_Maximum : 1266.0\n",
+      "\toriginal_firstorder_RootMeanSquared : 2829.57282108\n",
+      "\toriginal_firstorder_90Percentile : 1044.4\n",
+      "\toriginal_firstorder_Minimum : 468.0\n",
+      "\toriginal_firstorder_Entropy : 4.6019355539\n",
+      "\toriginal_firstorder_StandardDeviation : 156.611235894\n",
+      "\toriginal_firstorder_Range : 798.0\n",
+      "\toriginal_firstorder_Variance : 24527.0792084\n",
+      "\toriginal_firstorder_10Percentile : 632.0\n",
+      "\toriginal_firstorder_Kurtosis : 2.18077293939\n",
+      "\toriginal_firstorder_Mean : 825.235436307\n",
+      "\toriginal_glcm_SumVariance : 895.891808819\n",
+      "\toriginal_glcm_Homogeneity1 : 0.276140402104\n",
+      "\toriginal_glcm_Homogeneity2 : 0.189156155892\n",
+      "\toriginal_glcm_ClusterShade : -52.9707943386\n",
+      "\toriginal_glcm_MaximumProbability : 0.00792784235012\n",
+      "\toriginal_glcm_Idmn : 0.957796447609\n",
+      "\toriginal_glcm_SumVariance2 : 103.142793792\n",
+      "\toriginal_glcm_Contrast : 52.2310659277\n",
+      "\toriginal_glcm_DifferenceEntropy : 3.79686113536\n",
+      "\toriginal_glcm_InverseVariance : 0.188666637795\n",
+      "\toriginal_glcm_Entropy : 8.79428086119\n",
+      "\toriginal_glcm_Dissimilarity : 5.58932678922\n",
+      "\toriginal_glcm_DifferenceVariance : 17.6107741076\n",
+      "\toriginal_glcm_Idn : 0.866370546902\n",
+      "\toriginal_glcm_Idm : 0.189156155892\n",
+      "\toriginal_glcm_Correlation : 0.335214788202\n",
+      "\toriginal_glcm_Autocorrelation : 292.684050471\n",
+      "\toriginal_glcm_SumEntropy : 5.31547876648\n",
+      "\toriginal_glcm_AverageIntensity : 17.1242601309\n",
+      "\toriginal_glcm_Energy : 0.00290880217681\n",
+      "\toriginal_glcm_SumSquares : 39.9781084143\n",
+      "\toriginal_glcm_ClusterProminence : 26251.1709801\n",
+      "\toriginal_glcm_SumAverage : 33.4497492152\n",
+      "\toriginal_glcm_Imc2 : 0.692033706271\n",
+      "\toriginal_glcm_Imc1 : -0.091940840043\n",
+      "\toriginal_glcm_DifferenceAverage : 5.58932678922\n",
+      "\toriginal_glcm_Id : 0.276140402104\n",
+      "\toriginal_glcm_ClusterTendency : 103.142793792\n",
+      "\toriginal_glrlm_ShortRunLowGrayLevelEmphasis : 0.00822976624416\n",
+      "\toriginal_glrlm_GrayLevelVariance : 39.118151022\n",
+      "\toriginal_glrlm_LowGrayLevelRunEmphasis : 0.00860039789166\n",
+      "\toriginal_glrlm_GrayLevelNonUniformityNormalized : 0.0451412381498\n",
+      "\toriginal_glrlm_RunVariance : 0.0847945778959\n",
+      "\toriginal_glrlm_GrayLevelNonUniformity : 175.635192315\n",
+      "\toriginal_glrlm_LongRunEmphasis : 1.22684403826\n",
+      "\toriginal_glrlm_ShortRunHighGrayLevelEmphasis : 268.974179841\n",
+      "\toriginal_glrlm_RunLengthNonUniformity : 3500.04323157\n",
+      "\toriginal_glrlm_ShortRunEmphasis : 0.955939173141\n",
+      "\toriginal_glrlm_LongRunHighGrayLevelEmphasis : 341.286579098\n",
+      "\toriginal_glrlm_RunPercentage : 0.940406463249\n",
+      "\toriginal_glrlm_LongRunLowGrayLevelEmphasis : 0.0106011704787\n",
+      "\toriginal_glrlm_RunEntropy : 4.91503800316\n",
+      "\toriginal_glrlm_HighGrayLevelRunEmphasis : 281.066493909\n",
+      "\toriginal_glrlm_RunLengthNonUniformityNormalized : 0.895049465948\n",
+      "\toriginal_glszm_GrayLevelVariance : 40.6031399239\n",
+      "\toriginal_glszm_LowIntensityLargeAreaEmphasis : 0.127238415533\n",
+      "\toriginal_glszm_HighIntensitySmallAreaEmphasis : 193.438051926\n",
+      "\toriginal_glszm_SmallAreaEmphasis : 0.656447899959\n",
+      "\toriginal_glszm_LargeAreaEmphasis : 13.6155080214\n",
+      "\toriginal_glszm_ZoneVariance : 8.72123909749\n",
+      "\toriginal_glszm_SizeZoneVariabilityNormalized : 0.399784380451\n",
+      "\toriginal_glszm_LowIntensitySmallAreaEmphasis : 0.0064169820551\n",
+      "\toriginal_glszm_HighIntensityEmphasis : 288.623529412\n",
+      "\toriginal_glszm_IntensityVariabilityNormalized : 0.0440573079013\n",
+      "\toriginal_glszm_ZonePercentage : 0.4520183708\n",
+      "\toriginal_glszm_LowIntensityEmphasis : 0.00910094202771\n",
+      "\toriginal_glszm_SizeZoneVariability : 747.596791444\n",
+      "\toriginal_glszm_IntensityVariability : 82.3871657754\n",
+      "\toriginal_glszm_ZoneEntropy : 6.5082149862\n",
+      "\toriginal_glszm_HighIntensityLargeAreaEmphasis : 3514.76149733\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"Result type:\", type(result)  # result is returned in a Python ordered dictionary\n",
+    "print \"\"\n",
+    "print \"Calculated features\"\n",
+    "for key, value in result.iteritems():\n",
+    "    print \"\\t\", key, \":\", value"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,6 +118,15 @@ Developers
 :sup:`5`\ Kitware,
 :sup:`6`\ Isomics
 
+Contact
+-------
+We are happy to help you with any questions. Please contact us by sending an email to
+`info@radiomics.io <mailto:info@radiomics.io>`_.
+
+We'd welcome your contributions to PyRadiomics. Please read the
+`contributing guidelines <https://github.com/Radiomics/pyradiomics/blob/master/CONTRIBUTING.md>`_ on how to contribute
+to PyRadiomics.
+
 General references
 ------------------
 * HJWL Aerts, ER Velazquez, RTH Leijenaar, et al., "Decoding tumour phenotype by noninvasive imaging using a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,19 +120,8 @@ Developers
 
 Contact
 -------
-We are happy to help you with any questions. Please contact us by sending an email to
-`info@radiomics.io <mailto:info@radiomics.io>`_.
+We are happy to help you with any questions. Please contact us on the `pyradiomics email list <https://groups.google.com/forum/#!forum/pyradiomics>`_.
 
 We'd welcome your contributions to PyRadiomics. Please read the
 `contributing guidelines <https://github.com/Radiomics/pyradiomics/blob/master/CONTRIBUTING.md>`_ on how to contribute
 to PyRadiomics.
-
-General references
-------------------
-* HJWL Aerts, ER Velazquez, RTH Leijenaar, et al., "Decoding tumour phenotype by noninvasive imaging using a
-  quantitative radiomics approach", vol. 5, Nat Communication, 2014.
-  Available `here <http://www.nature.com/ncomms/2014/140603/ncomms5006/full/ncomms5006.html>`_.
-  Specifically, the formulation of the individual feature calculation is covered in this
-  `supplement <http://www.nature.com/ncomms/2014/140603/ncomms5006/extref/ncomms5006-s1.pdf>`_.
-* Zwanenburg A, Leger S, Vallières M, Löck S., "Image biomarker standardisation initiative - feature definitions",
-  arXiv:161207003. 2016. Available `here <http://arxiv.org/abs/1612.07003>`_.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,15 +2,55 @@
 Usage
 =====
 
+-----------------
+Instruction Video
+-----------------
+
+.. raw:: html
+
+        <div data-video = "ZF1rTtRW3eQ"
+        data-startseconds = "221"
+        data-endseconds = "538"
+        data-height = "315"
+        data-width = "560"
+        id = "youtube-player">
+        </div>
+
+        <script src="https://www.youtube.com/iframe_api"></script>
+        <script type="text/javascript">
+          function onYouTubeIframeAPIReady() {
+            var ctrlq = document.getElementById("youtube-player");
+            var player = new YT.Player('youtube-player', {
+              height: ctrlq.dataset.height,
+              width: ctrlq.dataset.width,
+              events: {
+                'onReady': function(e) {
+                  e.target.cueVideoById({
+                    videoId: ctrlq.dataset.video,
+                    startSeconds: ctrlq.dataset.startseconds,
+                    endSeconds: ctrlq.dataset.endseconds
+                  });
+                }
+              }
+            });
+          }
+        </script>
+
 -------
 Example
 -------
 
 * PyRadiomics example code and data is available in the `Github repository <https://github.com/Radiomics/pyradiomics>`_
 
-* The sample sample data is provided in ``pyradiomics/data``.
+* The sample sample data is provided in ``pyradiomics/data``
 
-* Use jupyter to run the helloRadiomics example, located in ``pyradiomics/bin/Notebooks``.
+* Use `jupyter <http://jupyter.org/>`_ to run the helloRadiomics example, located in ``pyradiomics/bin/Notebooks``
+
+* Jupyter can also be used to run the example notebook as shown in the instruction video
+
+  * The example notebook can be found in ``pyradiomics/bin/Notebooks``
+
+  * The parameter file used in the instruction video is available in ``pyradiomics/bin``
 
 * If jupyter is not installed, run the python script alternative (``pyradiomics/bin/helloRadiomics.py``):
 


### PR DESCRIPTION
Add a link to the pyradiomics webpage containing the instruction video to the README.
Additionally, embed the video in the usage section of the documentation, and running the usage example section.
Finally, include the python notebook used in the instruction video in pyradiomics/bin/Notebooks to enable hands-on testing