### PR TITLE
Move getFeatureClasses and getInputImages to radiomics namespace

### DIFF
--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -4,7 +4,12 @@ if sys.version_info < (2, 6, 0):
   raise ImportError("pyradiomics > 0.9.7 requires python 2.6 or later")
 in_py3 = sys.version_info[0] > 2
 
+import pkgutil
+import inspect
+import os
 import logging
+
+from . import base, imageoperations
 
 
 def debug(debug_on=True):
@@ -32,6 +37,54 @@ def debug(debug_on=True):
     debugging = False
 
 
+def getFeatureClasses():
+  """
+  Iterates over all modules of the radiomics package using pkgutil and subsequently imports those modules.
+
+  Return a dictionary of all modules containing featureClasses, with modulename as key, abstract
+  class object of the featureClass as value. Assumes only one featureClass per module
+
+  This is achieved by inspect.getmembers. Modules are added if it contains a member that is a class,
+  with name starting with 'Radiomics' and is inherited from :py:class:`radiomics.base.RadiomicsFeaturesBase`.
+
+  This iteration only runs once (at initialization of toolbox), subsequent calls return the dictionary created by the
+  first call.
+  """
+  global _featureClasses
+  if _featureClasses is None:  # On first call, enumerate possible feature classes and import PyRadiomics modules
+    _featureClasses = {}
+    for _, mod, _ in pkgutil.iter_modules([os.path.dirname(base.__file__)]):
+      if str(mod).startswith('_'):  # Skip loading of 'private' classes, these don't contain feature classes
+        continue
+      __import__('radiomics.' + mod)
+      module = sys.modules['radiomics.' + mod]
+      attributes = inspect.getmembers(module, inspect.isclass)
+      for a in attributes:
+        if a[0].startswith('Radiomics'):
+          if base.RadiomicsFeaturesBase in inspect.getmro(a[1])[1:]:
+            _featureClasses[mod] = a[1]
+
+  return _featureClasses
+
+
+def getInputImages():
+  """
+  Returns a list of possible input image types. This function finds the image types dynamically by matching the
+  signature ("get<inputImage>Image") against functions defined in :ref:`imageoperations
+  <radiomics-imageoperations-label>`. Returns a list containing available input image names (<inputImage> part of the
+  corresponding function name).
+
+  This iteration only occurs once, at initialization of the toolbox. Found results are stored and returned on subsequent
+  calls.
+  """
+  global _inputImages
+  if _inputImages is None:  # On first cal, enumerate possible input image types (original and any filters)
+    _inputImages = [member[3:-5] for member in dir(imageoperations)
+                    if member.startswith('get') and member.endswith("Image")]
+
+  return _inputImages
+
+
 debugging = True
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
@@ -41,6 +94,9 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 debug(False)  # force level=WARNING, in case logging default is set differently (issue 102)
 
+_featureClasses = None
+_inputImages = None
+
 # For convenience, import the most used packages into the "pyradiomics" namespace
 import collections, numpy
 
@@ -48,3 +104,6 @@ from ._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions
+
+getFeatureClasses()
+getInputImages()

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -67,7 +67,7 @@ def getFeatureClasses():
   return _featureClasses
 
 
-def getInputImages():
+def getInputImageTypes():
   """
   Returns a list of possible input image types. This function finds the image types dynamically by matching the
   signature ("get<inputImage>Image") against functions defined in :ref:`imageoperations
@@ -106,4 +106,4 @@ __version__ = get_versions()['version']
 del get_versions
 
 getFeatureClasses()
-getInputImages()
+getInputImageTypes()

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -6,7 +6,7 @@ from itertools import chain
 import SimpleITK as sitk
 import pykwalify.core
 import radiomics
-from radiomics import getFeatureClasses, getInputImages, imageoperations, generalinfo
+from radiomics import getFeatureClasses, getInputImageTypes, imageoperations, generalinfo
 
 
 class RadiomicsFeaturesExtractor:
@@ -64,7 +64,7 @@ class RadiomicsFeaturesExtractor:
     self.logger = logging.getLogger(__name__)
 
     self.featureClasses = getFeatureClasses()
-    self.inputImages = getInputImages()
+    self.inputImages = getInputImageTypes()
 
     self.kwargs = {}
     self.provenance_on = True

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -2,49 +2,51 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_docstrings.py
 
-from radiomics.featureextractor import RadiomicsFeaturesExtractor
+from radiomics import getFeatureClasses
 from testUtils import custom_name_func
 import logging
 from nose_parameterized import parameterized
 
-featureClasses = RadiomicsFeaturesExtractor.getFeatureClasses()
+featureClasses = getFeatureClasses()
+
 
 def setup_module(module):
-    # runs before anything in this file
-    print ("") # this is to get a newline after the dots
-    return
+  # runs before anything in this file
+  print ("")  # this is to get a newline after the dots
+  return
+
 
 class TestDocStrings:
-    def setup(self):
-        # setup before each test method
-        print ("") # this is to get a newline after the dots
+  def setup(self):
+    # setup before each test method
+    print ("")  # this is to get a newline after the dots
 
-    @classmethod
-    def setup_class(self):
-        # called before any methods in this class
-        print ("") # this is to get a newline after the dots
+  @classmethod
+  def setup_class(self):
+    # called before any methods in this class
+    print ("")  # this is to get a newline after the dots
 
-    @classmethod
-    def teardown_class(self):
-        # run after any methods in this class
-        print ("") # this is to get a newline after the dots
+  @classmethod
+  def teardown_class(self):
+    # run after any methods in this class
+    print ("")  # this is to get a newline after the dots
 
-    def generate_scenarios():
-      global featureClasses
-      for featureClassName, featureClass in featureClasses.iteritems():
-        logging.info('generate_scenarios %s', featureClassName)
-        doc = featureClass.__doc__
-        assert(doc != None)
+  def generate_scenarios():
+    global featureClasses
+    for featureClassName, featureClass in featureClasses.iteritems():
+      logging.info('generate_scenarios %s', featureClassName)
+      doc = featureClass.__doc__
+      assert (doc != None)
 
-        featureNames = featureClass.getFeatureNames()
-        for f in featureNames:
-          yield (featureClassName, f)
+      featureNames = featureClass.getFeatureNames()
+      for f in featureNames:
+        yield (featureClassName, f)
 
-    @parameterized.expand(generate_scenarios(), testcase_func_name=custom_name_func)
-    def test_class(self, featureClassName, featureName):
-      global featureClasses
-      logging.info('%s', featureName)
-      features = featureClasses[featureClassName]
-      doc = eval('features.get'+featureName+'FeatureValue.__doc__')
-      logging.info('%s', doc)
-      assert(doc != None)
+  @parameterized.expand(generate_scenarios(), testcase_func_name=custom_name_func)
+  def test_class(self, featureClassName, featureName):
+    global featureClasses
+    logging.info('%s', featureName)
+    features = featureClasses[featureClassName]
+    doc = eval('features.get' + featureName + 'FeatureValue.__doc__')
+    logging.info('%s', doc)
+    assert (doc != None)


### PR DESCRIPTION
Move the `getFeatureClasses` and `getInputImages` out of the RadiomicsFeaturesExtractor class and to the radiomics namespace.
This makes these functions more globally available (as it is also used in the testing, which does not necessarily use the featureextractor).

Additionally, add new parameter, "additionalInfo" (Boolean) to control wheter or not to append the extra information on the extraction to the output. This additional information is provided by the generalinfo.py module.