### PR TITLE
STYL: Fix import orders and enable flake8-import-order plugin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -33,4 +33,7 @@ ignore:
     E701,
     # .has_key() is deprecated, use 'in'
     W601,
-
+select: C,E,W,F,I
+# flake8-import-order
+application-import-names: radiomics,testUtils
+import-order-style: appnexus

--- a/bin/addClassToBaseline.py
+++ b/bin/addClassToBaseline.py
@@ -1,6 +1,7 @@
-import os
-import csv
 import collections
+import csv
+import os
+
 from radiomics import featureextractor, imageoperations
 
 

--- a/bin/batchExamples/DatasetHierarchyReader.py
+++ b/bin/batchExamples/DatasetHierarchyReader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import os
-import glob
 import collections
+import glob
+import os
 
 
 class DatasetHierarchyReader(object):

--- a/bin/batchExamples/GenerateInputCSV_Datasethierarchy.py
+++ b/bin/batchExamples/GenerateInputCSV_Datasethierarchy.py
@@ -1,5 +1,6 @@
-import os
 import csv
+import os
+
 from DatasetHierarchyReader import DatasetHierarchyReader
 
 

--- a/bin/batchExamples/GenerateInputCSV_Filename.py
+++ b/bin/batchExamples/GenerateInputCSV_Filename.py
@@ -1,5 +1,5 @@
-import os
 import csv
+import os
 
 SqDic = {}
 SqDic['T2-TSE-TRA'] = 't2tra'

--- a/bin/batchExamples/batchprocessing.py
+++ b/bin/batchExamples/batchprocessing.py
@@ -1,9 +1,11 @@
-import os
-import logging
-import csv
 import collections
+import csv
+import logging
+import os
 import traceback
+
 import SimpleITK as sitk
+
 import radiomics
 from radiomics import featureextractor
 

--- a/bin/helloFeatureClass.py
+++ b/bin/helloFeatureClass.py
@@ -1,7 +1,9 @@
 import os
-import SimpleITK as sitk
+
 import numpy
-from radiomics import firstorder, glcm, imageoperations, shape, glrlm, glszm
+import SimpleITK as sitk
+
+from radiomics import firstorder, glcm, glrlm, glszm, imageoperations, shape
 
 # testBinWidth = 25 this is the default bin size
 # testResampledPixelSpacing = [3,3,3] no resampling for now.

--- a/bin/helloRadiomics.py
+++ b/bin/helloRadiomics.py
@@ -1,8 +1,11 @@
-import os
 import logging
+import os
+
 import SimpleITK as sitk
-from radiomics import featureextractor
+
 import radiomics
+from radiomics import featureextractor
+
 
 testCase = 'brain1'
 dataDir = os.path.join(os.path.abspath(""), "..", "data")

--- a/bin/helloResampling.py
+++ b/bin/helloResampling.py
@@ -1,6 +1,9 @@
-from radiomics import imageoperations
-import SimpleITK as sitk
+
 import sys
+
+import SimpleITK as sitk
+
+from radiomics import imageoperations
 
 image = sitk.ReadImage(sys.argv[1])
 mask = sitk.ReadImage(sys.argv[2])

--- a/data/schemaFuncs.py
+++ b/data/schemaFuncs.py
@@ -1,8 +1,8 @@
 import pywt
+
 from radiomics.featureextractor import RadiomicsFeaturesExtractor
 
 featureClasses = RadiomicsFeaturesExtractor.getFeatureClasses()
-
 
 def checkWavelet(value, rule_obj, path):
   if not isinstance(value, basestring):

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -1,15 +1,21 @@
+
+# For convenience, import collection and numpy
+# into the "pyradiomics" namespace
+
+import collections  # noqa: F401
+import inspect
+import logging
+import os
+import pkgutil
 import sys
+
+import numpy  # noqa: F401
+
+from . import base, imageoperations
 
 if sys.version_info < (2, 6, 0):
   raise ImportError("pyradiomics > 0.9.7 requires python 2.6 or later")
 in_py3 = sys.version_info[0] > 2
-
-import pkgutil
-import inspect
-import os
-import logging
-
-from . import base, imageoperations
 
 
 def debug(debug_on=True):
@@ -96,9 +102,6 @@ debug(False)  # force level=WARNING, in case logging default is set differently 
 
 _featureClasses = None
 _inputImages = None
-
-# For convenience, import the most used packages into the "pyradiomics" namespace
-import collections, numpy  # noqa: F401
 
 from ._version import get_versions
 

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -1,9 +1,9 @@
+import inspect
 import logging
 import traceback
-import SimpleITK as sitk
-import numpy
-import inspect
 
+import numpy
+import SimpleITK as sitk
 
 class RadiomicsFeaturesBase(object):
   def __init__(self, inputImage, inputMask, **kwargs):

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
-import os
-import logging
 import collections
 from itertools import chain
-import SimpleITK as sitk
+import logging
+import os
+
 import pykwalify.core
+import SimpleITK as sitk
+
 import radiomics
-from radiomics import getFeatureClasses, getInputImageTypes, imageoperations, generalinfo
+from radiomics import generalinfo, getFeatureClasses, getInputImageTypes, imageoperations
 
 
 class RadiomicsFeaturesExtractor:

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -1,4 +1,5 @@
 import numpy
+
 from radiomics import base, imageoperations
 
 

--- a/radiomics/generalinfo.py
+++ b/radiomics/generalinfo.py
@@ -1,6 +1,8 @@
 import collections
 import logging
+
 import SimpleITK as sitk
+
 import radiomics
 
 

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -1,6 +1,8 @@
 import numpy
-from radiomics import base, imageoperations
+
 from tqdm import trange
+
+from radiomics import base, imageoperations
 
 
 class RadiomicsGLCM(base.RadiomicsFeaturesBase):

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -1,5 +1,7 @@
 from itertools import chain
+
 import numpy
+
 from radiomics import base, imageoperations
 
 

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -1,6 +1,7 @@
 import numpy
-from radiomics import base, imageoperations
 from tqdm import trange
+
+from radiomics import base, imageoperations
 
 
 class RadiomicsGLSZM(base.RadiomicsFeaturesBase):

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -1,8 +1,9 @@
 from itertools import chain
 import logging
-import SimpleITK as sitk
+
 import numpy
 import pywt
+import SimpleITK as sitk
 
 logger = logging.getLogger(__name__)
 

--- a/radiomics/scripts/commandline.py
+++ b/radiomics/scripts/commandline.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import argparse
-import sys
-import os.path
-import logging
 import collections
-import traceback
 import csv
 import json
+import logging
+import os.path
+import sys
+import traceback
+
 from radiomics import featureextractor
 
 parser = argparse.ArgumentParser()

--- a/radiomics/scripts/commandlinebatch.py
+++ b/radiomics/scripts/commandlinebatch.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import argparse
-import sys
-import os.path
-import logging
 import collections
-import traceback
 import csv
 import json
+import logging
+import os.path
+import sys
+import traceback
+
 from radiomics import featureextractor
 
 parser = argparse.ArgumentParser()

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -1,6 +1,7 @@
 import numpy
-from radiomics import base
 import SimpleITK as sitk
+
+from radiomics import base
 
 
 class RadiomicsShape(base.RadiomicsFeaturesBase):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 flake8
+flake8-import-order

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-import versioneer
-
-from setuptools.command.test import test as TestCommand
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
 
+import versioneer
 
 with open('requirements.txt', 'r') as fp:
     requirements = list(filter(bool, (line.strip() for line in fp)))

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1,11 +1,14 @@
-import SimpleITK as sitk
-import os
+
 import ast
 import csv
 import logging
 import math
-import numpy
+import os
+
 from nose_parameterized import parameterized
+import numpy
+import SimpleITK as sitk
+
 from radiomics import imageoperations
 
 # Get the logger. This is done outside the class, as it is needed by both the class and the custom_name_func

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -2,12 +2,15 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_docstrings.py
 
-from radiomics import getFeatureClasses
-from testUtils import custom_name_func
 import logging
+
 from nose_parameterized import parameterized
 
+from radiomics import getFeatureClasses
+from testUtils import custom_name_func
+
 featureClasses = getFeatureClasses()
+
 
 def setup_module(module):
     # runs before anything in this file

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2,11 +2,13 @@
 # setenv PYTHONPATH /path/to/pyradiomics/radiomics
 # nosetests --nocapture -v tests/test_features.py
 
-from radiomics.featureextractor import RadiomicsFeaturesExtractor
-from testUtils import RadiomicsTestUtils, custom_name_func
-import os
 import logging
+import os
+
 from nose_parameterized import parameterized
+
+from radiomics.featureextractor import RadiomicsFeaturesExtractor
+from testUtils import custom_name_func, RadiomicsTestUtils
 
 testUtils = RadiomicsTestUtils()
 testCases = testUtils.getTestCases()


### PR DESCRIPTION
The style "appnexus" is used, it allows to  group import per PEP8
recommendations [1], while keeping the project specific imports last.

[1] https://www.python.org/dev/peps/pep-0008/#imports