### PR TITLE
STYL: testUtils: Restore header sorting in test output

### DIFF
--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -249,7 +249,7 @@ class RadiomicsTestUtils:
     csvFile = open(fileName, 'w')
     csvFileWriter = csv.writer(csvFile)
     # get the headers from the first row
-    header = list(data[list(data.keys())[0]].keys())
+    header = sorted(data[list(data.keys())[0]].keys())
     header = ['testCase'] + header
     csvFileWriter.writerow(header)
     for testCase in sorted(data.keys()):

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -251,20 +251,20 @@ class RadiomicsTestUtils:
     # Get the headers from the first testCase in _testedSet
     # If no tests were run, the length of _testedSet will be 0, and no files should be written
     if len(self._testedSet) > 0:
-      csvFile = open(fileName, 'w')
-      csvFileWriter = csv.writer(csvFile, lineterminator='\n')
-      testedCases = sorted(self._testedSet)
-      header = sorted(data[testedCases[0]].keys())
-      header = ['testCase'] + header
-      csvFileWriter.writerow(header)
-      for testCase in testedCases:
-        thisCase = data[testCase]
-        thisCase['testCase'] = testCase
-        row = []
-        for h in header:
-          row = row + [thisCase.get(h, "N/A")]
-        csvFileWriter.writerow(row)
-      csvFile.close()
-      self._logger.info('Wrote to file %s', fileName)
+      with open(fileName, 'w') as csvFile:
+        csvFileWriter = csv.writer(csvFile, lineterminator='\n')
+        testedCases = sorted(self._testedSet)
+        header = sorted(data[testedCases[0]].keys())
+        header = ['testCase'] + header
+        csvFileWriter.writerow(header)
+        for testCase in testedCases:
+          thisCase = data[testCase]
+          thisCase['testCase'] = testCase
+          row = []
+          for h in header:
+            row = row + [thisCase.get(h, "N/A")]
+          csvFileWriter.writerow(row)
+        csvFile.close()
+        self._logger.info('Wrote to file %s', fileName)
     else:
       self._logger.info('No test cases run, aborting file write to %s', fileName)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -264,7 +264,6 @@ class RadiomicsTestUtils:
           for h in header:
             row = row + [thisCase.get(h, "N/A")]
           csvFileWriter.writerow(row)
-        csvFile.close()
         self._logger.info('Wrote to file %s', fileName)
     else:
       self._logger.info('No test cases run, aborting file write to %s', fileName)


### PR DESCRIPTION
This commit partially reverts commit d84c793 (STYL: testUtils: Improve
test outputs) and restore the sorting of columns written into the
CSV file.

Considering that data are organized using "featureClassName + featureName"
instead of just "featureName", information will remain consistently organized.

Suggested-by: Joost van Griethuysen <j.v.griethuysen@nki.nl>