### PR TITLE
Fix getFeatureClasses() in schemaFuncs.py

### DIFF
--- a/data/schemaFuncs.py
+++ b/data/schemaFuncs.py
@@ -1,9 +1,9 @@
 import pywt
 import six
 
-from radiomics.featureextractor import RadiomicsFeaturesExtractor
+from radiomics import getFeatureClasses
 
-featureClasses = RadiomicsFeaturesExtractor.getFeatureClasses()
+featureClasses = getFeatureClasses()
 
 def checkWavelet(value, rule_obj, path):
   if not isinstance(value, six.string_types):


### PR DESCRIPTION
`schemaFuncs.py` reflected the old implementation of `getFeatureClasses`, where it was implemented in `featureextractor`. As of 4771963, `getFeatureClasses` is implemented directly in the radiomics namespace. Update `schemaFuncs.py` accordingly.