### PR TITLE
ci: circleci: Do not fail if venv symlink is nonexistent

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,9 @@ dependencies:
 
 test:
   override:
-     - unlink venv # Workaround https://github.com/pypa/setuptools/pull/971
+     # Workaround https://github.com/pypa/setuptools/pull/971
+     - (unlink venv > /dev/null 2>&1 && echo "symlink removed") || echo "no symlink"
+
      - circleci-matrix:
         parallel: true
 


### PR DESCRIPTION
This commit improves the fix originally introduced in de8ee88 (ci:
manylinux: Avoid sdist failure with workaround for distutils/setuptools
issue)

Reported-by: Joost van Griethuysen <j.v.griethuysen@nki.nl>