### PR TITLE
Implement normalization function in imageoperations

### DIFF
--- a/data/paramSchema.yaml
+++ b/data/paramSchema.yaml
@@ -25,7 +25,9 @@ mapping:
         range:
           min-ex: 0
       removeOutliers:
-        type: bool
+        type: float
+        range:
+          min-ex: 0
       resampledPixelSpacing:
         seq:
           - type: int

--- a/data/paramSchema.yaml
+++ b/data/paramSchema.yaml
@@ -18,6 +18,14 @@ mapping:
         type: float
         range:
           min-ex: 0
+      normalize:
+        type: bool
+      normalizeScale:
+        type: float
+        range:
+          min-ex: 0
+      removeOutliers:
+        type: bool
       resampledPixelSpacing:
         seq:
           - type: int

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -15,7 +15,7 @@ from radiomics import generalinfo, getFeatureClasses, getInputImageTypes, imageo
 
 
 class RadiomicsFeaturesExtractor:
-  """
+  r"""
   Wrapper class for calculation of a radiomics signature.
   At and after initialisation various settings can be used to customize the resultant signature.
   This includes which classes and features to use, as well as what should be done in terms of preprocessing the image
@@ -28,7 +28,8 @@ class RadiomicsFeaturesExtractor:
   It initialisation, a parameters file can be provided containing all necessary settings. This is done by passing the
   location of the file as the single argument in the initialization call, without specifying it as a keyword argument.
   If such a file location is provided, any additional kwargs are ignored.
-  Alternatively, at initialisation, the following general settings can be specified in kwargs:
+  Alternatively, at initialisation, the following general settings can be specified in the parameter file or ``kwargs``,
+  with default values in brackets:
 
   - verbose [False]: Boolean, set to False to disable status update printing.
   - enableCExtensions [True]: Boolean, set to False to force calculation to full-python mode. See also
@@ -40,8 +41,11 @@ class RadiomicsFeaturesExtractor:
     :py:func:`~imageoperations.normalizeImage`.
   - normalizeScale [1]: Float, determines the scale after normalizing the image. If normalizing is disabled, this has
     no effect.
-  - removeOutliers [True]: Boolean, set to True to enable removal of outliers (mean +/- 3 stds) before normalizing the
-    image. If normalizing is disabled, this has no effect. See also :py:func:`~imageoperations.normalizeImage`.
+  - removeOutliers [None]: Float, defines the outliers to remove from the image. An outlier is defined as values that
+    differ more than :math:`n\sigma_x` from the mean, where :math:`n>0` and equal to the value of this setting. If this
+    parameter is omitted (providing it without a value (i.e. None) in the parameter file will throw an error), no
+    outliers are removed. If normalizing is disabled, this has no effect. See also
+    :py:func:`~imageoperations.normalizeImage`.
   - resampledPixelSpacing [None]: List of 3 floats, sets the size of the voxel in (x, y, z) plane when resampling.
   - interpolator [sitkBSpline]: Simple ITK constant or string name thereof, sets interpolator to use for resampling.
     Enumerated value, possible values:
@@ -90,7 +94,7 @@ class RadiomicsFeaturesExtractor:
       # Set default settings and update with and changed settings contained in kwargs
       self.kwargs = {'normalize': False,
                      'normalizeScale': 1,
-                     'removeOutliers': True,
+                     'removeOutliers': None,
                      'resampledPixelSpacing': None,  # No resampling by default
                      'interpolator': sitk.sitkBSpline,
                      'padDistance': 5,
@@ -182,7 +186,7 @@ class RadiomicsFeaturesExtractor:
     # Set default settings and update with and changed settings contained in kwargs
     self.kwargs = {'normalize': False,
                    'normalizeScale': 1,
-                   'removeOutliers': True,
+                   'removeOutliers': None,
                    'resampledPixelSpacing': None,  # No resampling by default
                    'interpolator': sitk.sitkBSpline,
                    'padDistance': 5,

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -138,7 +138,8 @@ def cropToTumorMask(imageNode, maskNode, label=1, boundingBox=None):
 
 
 def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.sitkBSpline, label=1, padDistance=5):
-  """Resamples image or label to the specified pixel spacing (The default interpolator is Bspline)
+  """
+  Resamples image or label to the specified pixel spacing (The default interpolator is Bspline)
 
   'imageNode' is a SimpleITK Object, and 'resampledPixelSpacing' is the output pixel spacing (list of 3 elements).
 
@@ -231,6 +232,41 @@ def resampleImage(imageNode, maskNode, resampledPixelSpacing, interpolator=sitk.
 
   return resampledImageNode, resampledMaskNode
 
+def normalizeImage(image, scale=1, removeOutliers=True):
+  r"""
+  Normalizes the image by centering it at the mean with standard deviation. Normalization is based on all gray values in
+  the image, not just those inside the segementation.
+
+  :math:`f(x) = \frac{s(x - \mu_x)}{\sigma_x}`
+
+  Where:
+
+  - :math:`x` and :math:`f(x)` are the original and normalized intensity, respectively.
+  - :math:`\mu_x` and :math:`\sigma_x` are the mean and standard deviation of the image instensity values.
+  - :math:`s` is an optional scaling defined by ``scale``. By default, it is set to 1.
+
+  Optionally, outliers can be removed, in which case values for which :math:`x > \mu_x + 3\sigma_x` or
+  :math:`x < \mu_x - 3\sigma_x` are set to :math:`\mu_x + 3\sigma_x` and :math:`\mu_x - 3\sigma_x`, respectively.
+  This is done before the values of the image are normalized.
+  """
+
+  if removeOutliers:
+    imageArr = sitk.GetArrayFromImage(image)
+    mu = numpy.mean(imageArr)
+    sigma = numpy.std(imageArr)
+
+    imageArr[imageArr > (mu + 3 * sigma)] = mu + 3 * sigma
+    imageArr[imageArr < (mu - 3 * sigma)] = mu - 3 * sigma
+
+    newImage = sitk.GetImageFromArray(imageArr)
+    newImage.CopyInformation(image)
+  else:
+    newImage = image
+
+  image = sitk.Normalize(newImage) * scale
+
+  return image
+
 
 def applyThreshold(inputImage, lowerThreshold, upperThreshold, insideValue=None, outsideValue=0):
   # this mode is useful to generate the mask of thresholded voxels
@@ -309,32 +345,32 @@ def getLoGImage(inputImage, **kwargs):
 
 def getWaveletImage(inputImage, **kwargs):
   """
-      Apply wavelet filter to image and compute signature for each filtered image.
+  Apply wavelet filter to image and compute signature for each filtered image.
 
-      Following settings are possible:
+  Following settings are possible:
 
-      - start_level [0]: integer, 0 based level of wavelet which should be used as first set of decompositions
-        from which a signature is calculated
-      - level [1]: integer, number of levels of wavelet decompositions from which a signature is calculated.
-      - wavelet ["coif1"]: string, type of wavelet decomposition. Enumerated value, validated against possible values
-        present in the ``pyWavelet.wavelist()``. Current possible values (pywavelet version 0.4.0) (where an
-        aditional number is needed, range of values is indicated in []):
+  - start_level [0]: integer, 0 based level of wavelet which should be used as first set of decompositions
+    from which a signature is calculated
+  - level [1]: integer, number of levels of wavelet decompositions from which a signature is calculated.
+  - wavelet ["coif1"]: string, type of wavelet decomposition. Enumerated value, validated against possible values
+    present in the ``pyWavelet.wavelist()``. Current possible values (pywavelet version 0.4.0) (where an
+    aditional number is needed, range of values is indicated in []):
 
-        - haar
-        - dmey
-        - sym[2-20]
-        - db[1-20]
-        - coif[1-5]
-        - bior[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
-        - rbio[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
+    - haar
+    - dmey
+    - sym[2-20]
+    - db[1-20]
+    - coif[1-5]
+    - bior[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
+    - rbio[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
 
-      Returned filter name reflects wavelet type:
-      wavelet[level]-<decompositionName>
+  Returned filter name reflects wavelet type:
+  wavelet[level]-<decompositionName>
 
-      N.B. only levels greater than the first level are entered into the name.
+  N.B. only levels greater than the first level are entered into the name.
 
-      :return: Yields each wavelet decomposition and final approximation, corresponding filter name and ``kwargs``
-      """
+  :return: Yields each wavelet decomposition and final approximation, corresponding filter name and ``kwargs``
+  """
   global logger
 
   approx, ret = _swt3(inputImage, kwargs.get('wavelet', 'coif1'), kwargs.get('level', 1), kwargs.get('start_level', 0))


### PR DESCRIPTION
Optionally normalize gray value intensities before any resampling or filters are applied. Image is normalized on all gray values (not just those in the ROI). Disabled by default. Controlled by 3 new params (`normalize`, `normalizeScale` and `removeOutliers`).