### PR TITLE
Fix pyradiomicsbatch error with python 3

### DIFF
--- a/radiomics/scripts/commandlinebatch.py
+++ b/radiomics/scripts/commandlinebatch.py
@@ -99,9 +99,9 @@ def main():
         if args.format == 'csv':
           writer = csv.writer(args.outFile, lineterminator='\n')
           if not headers:
-            writer.writerow(featureVector.keys())
+            writer.writerow(list(featureVector.keys()))
             headers = True
-          writer.writerow(featureVector.values())
+          writer.writerow(list(featureVector.values()))
         elif args.format == 'json':
           json.dump(featureVector, args.out)
           args.out.write('\n')


### PR DESCRIPTION
In python 3.x (tested 3.4) featureVector.keys() and
featureVector.values() don’t return a sequence expected in
writer.writerow() causing the error:

writer.writerow(featureVector.keys())
_csv.Error: sequence expected

writer.writerow(featureVector.values())
_csv.Error: sequence expected
