### PR TITLE
setup: use scikit-build for building cmatrices and cshape C extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# scikit-build
+_skbuild
+MANIFEST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(radiomics)
+
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs REQUIRED)
+find_package(PythonExtensions REQUIRED)
+
+add_subdirectory(radiomics/src)
+

--- a/radiomics/src/CMakeLists.txt
+++ b/radiomics/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(NumPy REQUIRED)
+
+add_library(_cmatrices MODULE _cmatrices.c cmatrices.c)
+python_extension_module(_cmatrices)
+target_include_directories(_cmatrices PRIVATE ${NumPy_INCLUDE_DIR})
+
+add_library(_cshape MODULE _cshape.c cshape.c)
+python_extension_module(_cshape)
+target_include_directories(_cshape PRIVATE ${NumPy_INCLUDE_DIR})
+
+install(TARGETS _cmatrices _cshape LIBRARY DESTINATION radiomics)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
+cmake
 flake8
 flake8-import-order
+scikit-build

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -54,6 +54,7 @@ build:
 
 test:
   commands:
+    - $<RUN_ENV> pip install -e .
     - $<RUN_ENV> python setup.py test  --args="--with-xunit --logging-level=DEBUG"
 
   circleci:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 
-from distutils import sysconfig
-
-import numpy
-
-from setuptools import Extension, setup
-
 from setuptools.command.test import test as TestCommand
+from skbuild import setup
 
 
 import versioneer
@@ -45,13 +40,6 @@ class NoseTestCommand(TestCommand):
 commands = versioneer.get_cmdclass()
 commands['test'] = NoseTestCommand
 
-incDirs = [sysconfig.get_python_inc(), numpy.get_include()]
-
-ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomics/src/cmatrices.c"],
-                 include_dirs=incDirs),
-       Extension("radiomics._cshape", ["radiomics/src/_cshape.c", "radiomics/src/cshape.c"],
-                 include_dirs=incDirs)]
-
 setup(
     name='pyradiomics',
 
@@ -64,7 +52,6 @@ setup(
     cmdclass=commands,
 
     packages=['radiomics', 'radiomics.scripts'],
-    ext_modules=ext,
     zip_safe=False,
     data_files=[
       ('data', ['data/paramSchema.yaml', 'data/schemaFuncs.py'])],


### PR DESCRIPTION
This commit introduces a new dependencies to "scikit-built" and "cmake".

scikit-build is a drop-in replacement to setuptools.setup function
allowing to easily compile and package extensions (C/C++/Cython) by
bridging CMake and setuptools. See http://scikit-build.org

CMake is is an open-source, cross-platform family of tools designed
to build, test and package software. See https://cmake.org

Currently, scikit-build and cmake have to be explicitly (see [1]) installed
on the system. This could be done by simply doing:

  pip install scikit-build cmake

How does it work ?
------------------

In addition to simplifying setup.py, two new file have been added:

```
<root>
  |
  |---- CMakeLists.txt                          (1)
  .
  .
  .
  |--- ...src
  |        |--- CMakeLists.txt                  (2)
  .
  .
```

The first CMakeLists.txt specifies requirements for

* Python interpreter,

* the associated python libraries

* and a "PythonExtension" modules containing convenience CMake
  functions allowing to easily build extension by encapsulating
  system introspection and platform specific logic.

and include the subdirectory associated with the other CMakeLists.txt.

The second CMakeLists.txt is specific to "cmatrices" and "cshape"
extensions and it specifies:

* requirement for NumPy

Then, it declares:

* libraries for each extension, associate python extension specific properties

* and finally add an install rule specifying where in the package
  hierarchy the extension should be installed.

Et voila,

[1] Note that improvement to python packaging will be available shortly and
it will be possible to include scikit-build and cmake directly in pyproject.toml
See here for more details: https://www.python.org/dev/peps/pep-0518/