### PR TITLE
Further improve python 3 compatibility.

### DIFF
--- a/bin/addClassToBaseline.py
+++ b/bin/addClassToBaseline.py
@@ -27,9 +27,8 @@ def main():
             'gldm_a': 0}
 
   extractor = featureextractor.RadiomicsFeaturesExtractor(**kwargs)
-  featureClasses = extractor.getFeatureClassNames()
 
-  for cls in featureClasses:
+  for cls in extractor.getFeatureClassNames():
     if os.path.exists(os.path.join(baselineDir, 'baseline_%s.csv' % (cls))):
       with open(os.path.join(baselineDir, 'baseline_%s.csv' % (cls)), 'rb') as baselineFile:
         csvReader = csv.reader(baselineFile)
@@ -42,7 +41,7 @@ def main():
     print("No baselinefiles containing testcases found, exiting...")
     exit(-1)
 
-  newClasses = [cls for cls in featureClasses if
+  newClasses = [cls for cls in extractor.getFeatureClassNames() if
                 not os.path.exists(os.path.join(baselineDir, 'baseline_%s.csv' % (cls)))]
 
   if len(newClasses) == 0:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -14,7 +14,6 @@ testUtils = RadiomicsTestUtils()
 testCases = testUtils.getTestCases()
 
 extractor = RadiomicsFeaturesExtractor()
-featureClassNames = extractor.getFeatureClassNames()
 
 featureClass = None
 
@@ -23,10 +22,9 @@ class TestFeatures:
   def generate_scenarios():
     global testCases
     global extractor
-    global featureClassNames
 
     for testCase in testCases:
-      for featureClassName in featureClassNames:
+      for featureClassName in extractor.getFeatureClassNames():
         featureNames = extractor.featureClasses[featureClassName].getFeatureNames()
         assert (featureNames is not None)
         assert (len(featureNames) > 0)


### PR DESCRIPTION
In `addClassToBaseline`, code was not python 3 compatible. This was mainly due to a call to keys(), which in python 2 returns a list, but in python 3 returns an iterator.

cc @Radiomics/developers 