### PR TITLE
Implement forced 2D texture extraction.

### DIFF
--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -43,6 +43,7 @@ class RadiomicsFeaturesBase(object):
     self.logger.debug('Initializing feature class')
     self.verbose = radiomics.handler.level <= logging.INFO  # check if the handler to stderr is set to INFO or lower
 
+    self.kwargs = kwargs
     self.binWidth = kwargs.get('binWidth', 25)
     self.label = kwargs.get('label', 1)
 

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -65,6 +65,16 @@ class RadiomicsFeaturesExtractor:
     Padding is needed for some filters (e.g. LoG). Value of padded voxels are set to original gray level intensity,
     padding does not exceed original image boundaries. **N.B. After application of filters image is cropped again
     without padding.**
+  - distances [[1]]: List of integers. This specifies the distances between the center voxel and the neighbor, for which
+    angles should be generated. See also :py:func:`~radiomics.imageoperations.generateAngles()`
+  - force2Dextraction [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
+    the 'slice' can be defined in ``force2Ddimension``. If input ROI is already a 2D ROI, features are automatically
+    extracted in 2D. See also :py:func:`~radiomics.imageoperations.generateAngles()`
+  - force2Ddimension [0]: int, range 0-2. Specifies the 'slice' dimension for a by-slice feature extraction. Value 0
+    identifies the 'z' dimension (axial plane feature extraction), and features will be extracted from the xy plane.
+    Similarly, 1 identifies the y dimension (coronal plane) and 2 the x dimension (saggital plane). if
+    ``force2Dextraction`` is set to False, this parameter has no effect. See also
+    :py:func:`~radiomics.imageoperations.generateAngles()`
 
   .. note::
 

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -67,7 +67,7 @@ class RadiomicsFeaturesExtractor:
     without padding.**
   - distances [[1]]: List of integers. This specifies the distances between the center voxel and the neighbor, for which
     angles should be generated. See also :py:func:`~radiomics.imageoperations.generateAngles()`
-  - force2Dextraction [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
+  - force2D [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
     the 'slice' can be defined in ``force2Ddimension``. If input ROI is already a 2D ROI, features are automatically
     extracted in 2D. See also :py:func:`~radiomics.imageoperations.generateAngles()`
   - force2Ddimension [0]: int, range 0-2. Specifies the 'slice' dimension for a by-slice feature extraction. Value 0
@@ -130,6 +130,9 @@ class RadiomicsFeaturesExtractor:
             'resampledPixelSpacing': None,  # No resampling by default
             'interpolator': 'sitkBSpline',  # Alternative: sitk.sitkBSpline,
             'padDistance': 5,
+            'distances': [1],
+            'force2D': False,
+            'force2Ddimension': 0,
             'label': 1,
             'enableCExtensions': True,
             'additionalInfo': True}

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -147,7 +147,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     self.matrix[self.maskArray == 0] = -1
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
 
     P_glcm = numpy.zeros((Ng, Ng, int(angles.shape[0])), dtype='float64')
 
@@ -185,7 +185,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     self.logger.debug("Calculating GLCM matrix in C")
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
     Ng = self.coefficients['Ng']
 
     P_glcm = cMatrices.calculate_glcm(self.matrix, self.maskArray, angles, Ng)

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -113,7 +113,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     matrixDiagonals = []
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
 
     self.logger.debug('Calculating diagonals')
     for angle in angles:
@@ -172,7 +172,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
 
     P_glrlm = cMatrices.calculate_glrlm(self.matrix, self.maskArray, angles, Ng, Nr)
     P_glrlm = self._applyMatrixOptions(P_glrlm, angles)

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -84,7 +84,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     self.logger.debug("Calculating GLSZM matrix in Python")
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
 
     # Empty GLSZ matrix
     P_glszm = numpy.zeros((self.coefficients['Ng'], self.coefficients['Np']))
@@ -145,7 +145,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     self.logger.debug("Calculating GLSZM matrix in C")
 
     size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    angles = imageoperations.generateAngles(size, **self.kwargs)
     Ng = self.coefficients['Ng']
     Ns = self.coefficients['Np']
 

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -76,7 +76,7 @@ def generateAngles(size, **kwargs):
 
     - distances [[1]]: List of integers. This specifies the distances between the center voxel and the neighbor, for
       which angles should be generated.
-    - force2Dextraction [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
+    - force2D [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
       the 'slice' can be defined in ``force2Ddimension``. If input ROI is already a 2D ROI, features are automatically
       extracted in 2D.
     - force2Ddimension [0]: int, range 0-2. Specifies the 'slice' dimension for a by-slice feature extraction. Value 0
@@ -91,7 +91,7 @@ def generateAngles(size, **kwargs):
   logger.debug("Generating angles")
 
   distances = kwargs.get('distances', [1])
-  force2Dextraction = kwargs.get('force2Dextraction', False)
+  force2Dextraction = kwargs.get('force2D', False)
   force2Ddimension = kwargs.get('force2Ddimension', 0)
 
   maxDistance = max(distances)

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -58,25 +58,46 @@ def binImage(binwidth, parameterMatrix, parameterMatrixCoordinates):
   return parameterMatrix, histogram
 
 
-def generateAngles(size, maxDistance=1):
-  """
-  Generate all possible angles from distance 1 until maxDistance in 3D.
+def generateAngles(size, **kwargs):
+  r"""
+  Generate all possible angles from distance 1 until the maximum distance in ``distances`` in 3D.
   E.g. for d = 1, 13 angles are generated (representing the 26-connected region).
   For d = 2, 13 + 49 = 62 angles are generated (representing the 26 connected region for distance 1, and the 98
   connected region for distance 2)
 
-  Impossible angles (where 'neighbouring' voxels will always be outside delineation) are deleted.
+  First, only generated angles are retained, for which the maximum step size in any dimension (i.e. the infinity norm
+  distance from the center voxel) is present in ``distances``. Next, impossible angles (where 'neighbouring' voxels will
+  always be outside delineation) are deleted. Finally, if ``force2Dextraction`` is enabled, all angles
+  defining a step in the ``force2Ddimension`` are removed (e.g. if this dimension is 0, all angles that have a non-zero
+  step size at index 0 (z dimension) are removed, resulting in angles that only move in the x and/or y dimension).
 
   :param size: dimensions (z, x, y) of the bounding box of the tumor mask.
-  :param maxDistance: [1] Maximum distance between center voxel and neighbour
+  :param kwargs: The following additional parameters can be specified here (default values in brackets):
+
+    - distances [[1]]: List of integers. This specifies the distances between the center voxel and the neighbor, for
+      which angles should be generated.
+    - force2Dextraction [False]: Boolean, set to true to force a by slice texture calculation. Dimension that identifies
+      the 'slice' can be defined in ``force2Ddimension``. If input ROI is already a 2D ROI, features are automatically
+      extracted in 2D.
+    - force2Ddimension [0]: int, range 0-2. Specifies the 'slice' dimension for a by-slice feature extraction. Value 0
+      identifies the 'z' dimension (axial plane feature extraction), and features will be extracted from the xy plane.
+      Similarly, 1 identifies the y dimension (coronal plane) and 2 the x dimension (saggital plane). if
+      ``force2Dextraction`` is set to False, this parameter has no effect.
+
   :return: numpy array with shape (N, 3), where N is the number of unique angles
   """
   global logger
 
   logger.debug("Generating angles")
 
+  distances = kwargs.get('distances', [1])
+  force2Dextraction = kwargs.get('force2Dextraction', False)
+  force2Ddimension = kwargs.get('force2Ddimension', 0)
+
+  maxDistance = max(distances)
   angles = []
 
+  # Generate all possible angles for distance = 1 to maxDistance
   for z in range(1, maxDistance + 1):
     angles.append((0, 0, z))
     for y in range(-maxDistance, maxDistance + 1):
@@ -84,9 +105,18 @@ def generateAngles(size, maxDistance=1):
       for x in range(-maxDistance, maxDistance + 1):
         angles.append((z, y, x))
 
-  angles = numpy.array(angles)
+  if maxDistance > 1:  # multiple distances, check if some angles need to be removed
+    angles = numpy.array([angle for angle in angles if numpy.max(numpy.abs(angle)) in distances])
+  else:  # all generated angles must be retained
+    angles = numpy.array(angles)
 
+  # Remove 'impossible' angles: these angles always point to a 'neighbor' outside the ROI and therefore never yield a
+  # valid voxel-pair.
   angles = numpy.delete(angles, numpy.where(numpy.min(size - numpy.abs(angles), 1) <= 0), 0)
+
+  if force2Dextraction:
+    # Remove all angles that move in the force2Ddimension, retaining all that move only in the force 2D plane
+    angles = numpy.delete(angles, numpy.where(angles[:, force2Ddimension] != 0), 0)
 
   logger.debug("Generated %d angles", len(angles))
 

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -38,6 +38,18 @@ mapping:
         type: int
         range:
           min: 0
+      distances:
+        seq:
+          - type: int
+            range:
+              min-ex: 0
+      force2D:
+        type: bool
+      force2Ddimension:
+        type: int
+        range:
+          min: 0
+          max: 2
       sigma:
         seq:
           - type: float


### PR DESCRIPTION
Add additional parameters to optionally force texture calculation to 2D. This is enabled by setting parameter `force2Dextraction` to True. Then, all angles moving across 'slices' are removed. The dimension which specifies the slice is defined in `force2Ddimension`. For example, if enabled and dimension is 0, texture is extracted only in the xy-plane (with dimension 0 specifying the 'z' dimension as slice-dimension). Forced 2D extraction is switched off by default.

Additionally, enable specifying custom distances between center voxel and neighbors. These distances are specified in the `distances` parameter as a list of integers. By default `disances = [1]`.