### PR TITLE
Add sphinx_rtd_theme to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyWavelets>=0.4.0
 pykwalify>=1.6.0
 six>=1.10.0
 sphinx>=1.4
+sphinx_rtd_theme>=0.2.2


### PR DESCRIPTION
To build the documentation, both sphinx and the read the docs theme is necessary, but the latter was not specified in the requirements.