### PR TITLE
BUG: Correct Np when weighting is applied

### DIFF
--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -197,6 +197,9 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     # Optionally apply a weighting factor
     if self.weightingNorm is not None:
       self.logger.debug('Applying weighting (%s)', self.weightingNorm)
+      # Correct the number of voxels for the number of times it is used (once per angle), affects run percentage
+      self.coefficients['Np'] *= len(angles)
+
       pixelSpacing = self.inputImage.GetSpacing()[::-1]
       weights = numpy.empty(len(angles))
       for a_idx, a in enumerate(angles):


### PR DESCRIPTION
Every voxel in the ROI is considered once per angle in GLRLM.
When weighting is applied in GLRLM, Np has to be corrected, as all angles are combined into one matrix, which mean Np has to reflect the number of voxels assessed (equals number of voxels in ROI * number of times each voxel is assessed).