### PR TITLE
Add function to get test case

### DIFF
--- a/bin/Notebooks/PyRadiomics Example.ipynb
+++ b/bin/Notebooks/PyRadiomics Example.ipynb
@@ -27,6 +27,7 @@
     "import six\n",
     "import os  # needed navigate the system to get the input data\n",
     "\n",
+    "import radiomics\n",
     "from radiomics import featureextractor  # This module is used for interaction with pyradiomics"
    ]
   },
@@ -43,7 +44,7 @@
    "source": [
     "Before we can extract features, we need to get the input data, define the parameters for the extraction and instantiate the class contained within `featureextractor`.\n",
     "\n",
-    "In the next cell we get our testing data, this consists of an image and corresponding segmentation. This is also available from the PyRadiomics repository and is stored in `\\pyradiomics\\data`, whereas this file (and therefore, the current directory) is `\\pyradiomics\\bin\\Notebooks`"
+    "In the next cell we get our testing data, this consists of an image and corresponding segmentation. This is also available from the PyRadiomics repository and is stored in `\\pyradiomics\\data`. The test case can be obtained using `radiomic.getTestCase`. This function returns the file location of the image and mask of the requested test case. If no locally available test case can be found, PyRadiomics downloads it from GitHub and stores it in temporary files. By specifying the (relative) path to the repository root, PyRadiomics is able to find test data included in the repository, preventing unnecessary downloads. If the this path is invalid (test case files not found), PyRadiomics will also revert to downloading it."
    ]
   },
   {
@@ -57,27 +58,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dataDir, relative path: E:\\Git-Repos\\pyradiomics\\bin\\Notebooks\\..\\..\\data\n",
-      "dataDir, absolute path: E:\\Git-Repos\\pyradiomics\\data\n",
+      "repositoryRoot, relative path: E:\\Git-Repos\\pyradiomics\\bin\\Notebooks\\..\\..\n",
+      "repositoryRoot, absolute path: E:\\Git-Repos\\pyradiomics\n",
       "Parameter file, absolute path: E:\\Git-Repos\\pyradiomics\\bin\\Params.yaml\n"
      ]
     }
    ],
    "source": [
-    "# Define the testcase name\n",
-    "testCase = 'brain1'\n",
+    "# Get the location of the repository, relative to this Notebook (assumes it is run from \\pyradiomics\\bin\\Notebooks)\n",
+    "repositoryRoot = os.path.join(os.getcwd(), \"..\", \"..\")\n",
+    "print(\"repositoryRoot, relative path:\", repositoryRoot)\n",
+    "print(\"repositoryRoot, absolute path:\", os.path.abspath(repositoryRoot))\n",
     "\n",
-    "# Get the relative path to pyradiomics\\data\n",
-    "# os.cwd() returns the current working directory\n",
-    "# \"..\" points to the parent directory: \\pyradiomics\\bin\\Notebooks\\..\\ is equal to \\pyradiomics\\bin\\\n",
-    "# Move up 2 directories (i.e. go to \\pyradiomics\\) and then move into \\pyradiomics\\data\n",
-    "dataDir = os.path.join(os.getcwd(), \"..\", \"..\", \"data\")\n",
-    "print(\"dataDir, relative path:\", dataDir)\n",
-    "print(\"dataDir, absolute path:\", os.path.abspath(dataDir))\n",
+    "# Get the testCase\n",
+    "imagePath, maskPath = radiomics.getTestCase('brain1', repositoryRoot)\n",
     "\n",
-    "# Store the file paths of our testing image and label map into two variables\n",
-    "imagePath = os.path.join(dataDir, testCase + \"_image.nrrd\")\n",
-    "labelPath = os.path.join(dataDir, testCase + \"_label.nrrd\")\n",
+    "if imageName is None or maskName is None:  # Something went wrong, in this case PyRadiomics will also log an error\n",
+    "    print('Error getting testcase!')\n",
     "\n",
     "# Additonally, store the location of the example parameter file, stored in \\pyradiomics\\bin\n",
     "paramPath = os.path.join(os.getcwd(), \"..\", \"Params.yaml\")\n",
@@ -124,7 +121,7 @@
      "output_type": "stream",
      "text": [
       "Extraction parameters:\n",
-      "\t {'additionalInfo': True, 'verbose': False, 'enableCExtensions': True, 'label': 1, 'interpolator': 3, 'resampledPixelSpacing': None, 'padDistance': 5}\n",
+      "\t {'distances': [1], 'additionalInfo': True, 'enableCExtensions': True, 'force2D': False, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'label': 1, 'normalizeScale': 1, 'normalize': False, 'force2Ddimension': 0, 'removeOutliers': None, 'minimumROISize': None, 'minimumROIDimensions': 1, 'padDistance': 5}\n",
       "Enabled filters:\n",
       "\t {'Original': {}}\n",
       "Enabled features:\n",
@@ -160,7 +157,7 @@
      "output_type": "stream",
      "text": [
       "Extraction parameters:\n",
-      "\t {'additionalInfo': True, 'verbose': True, 'binWidth': 20, 'enableCExtensions': True, 'label': 1, 'interpolator': 3, 'resampledPixelSpacing': None, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
+      "\t {'distances': [1], 'verbose': True, 'additionalInfo': True, 'enableCExtensions': True, 'force2D': False, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'label': 1, 'normalizeScale': 1, 'normalize': False, 'force2Ddimension': 0, 'removeOutliers': None, 'minimumROISize': None, 'binWidth': 20, 'minimumROIDimensions': 1, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
       "Enabled filters:\n",
       "\t {'Original': {}}\n",
       "Enabled features:\n",
@@ -195,7 +192,7 @@
      "output_type": "stream",
      "text": [
       "Extraction parameters:\n",
-      "\t {'additionalInfo': True, 'verbose': True, 'binWidth': 20, 'enableCExtensions': True, 'label': 1, 'interpolator': 3, 'resampledPixelSpacing': None, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
+      "\t {'distances': [1], 'verbose': True, 'additionalInfo': True, 'enableCExtensions': True, 'force2D': False, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'label': 1, 'normalizeScale': 1, 'normalize': False, 'force2Ddimension': 0, 'removeOutliers': None, 'minimumROISize': None, 'binWidth': 20, 'minimumROIDimensions': 1, 'sigma': [1, 2, 3], 'padDistance': 5}\n",
       "Enabled filters:\n",
       "\t {'Original': {}}\n",
       "Enabled features:\n",
@@ -272,11 +269,11 @@
      "output_type": "stream",
      "text": [
       "Extraction parameters:\n",
-      "\t {'additionalInfo': True, 'verbose': True, 'binWidth': 25, 'enableCExtensions': True, 'label': 1, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'weightingNorm': None, 'padDistance': 5}\n",
+      "\t {'distances': [1], 'additionalInfo': True, 'enableCExtensions': True, 'weightingNorm': None, 'force2D': False, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'label': 1, 'normalizeScale': 1, 'normalize': False, 'force2Ddimension': 0, 'removeOutliers': None, 'minimumROISize': None, 'binWidth': 25, 'minimumROIDimensions': 1, 'padDistance': 5}\n",
       "Enabled filters:\n",
       "\t {'Original': {}}\n",
       "Enabled features:\n",
-      "\t {'firstorder': [], 'glcm': None, 'shape': None, 'glrlm': None, 'glszm': None}\n"
+      "\t {'firstorder': [], 'glcm': None, 'shape': ['Volume', 'SurfaceArea', 'SurfaceVolumeRatio', 'Sphericity', 'SphericalDisproportion', 'Maximum3DDiameter', 'Maximum2DDiameterSlice', 'Maximum2DDiameterColumn', 'Maximum2DDiameterRow', 'Elongation', 'Flatness'], 'glrlm': None, 'glszm': None}\n"
      ]
     }
    ],
@@ -311,21 +308,9 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\t\tComputing shape\n",
-      "\t\tComputing firstorder\n",
-      "\t\tComputing glcm\n",
-      "\t\tComputing glrlm\n",
-      "\t\tComputing glszm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "result = extractor.execute(imagePath, labelPath)"
+    "result = extractor.execute(imagePath, maskPath)"
    ]
   },
   {
@@ -343,26 +328,23 @@
       "Result type: <class 'collections.OrderedDict'>\n",
       "\n",
       "Calculated features\n",
-      "\t general_info_BoundingBox : (162; 84; 11; 47; 70; 7)\n",
-      "\t general_info_GeneralSettings : {'additionalInfo': True; 'verbose': True; 'binWidth': 25; 'enableCExtensions': True; 'label': 1; 'interpolator': 'sitkBSpline'; 'resampledPixelSpacing': None; 'weightingNorm': None; 'padDistance': 5}\n",
+      "\t general_info_BoundingBox : (162, 84, 11, 47, 70, 7)\n",
+      "\t general_info_GeneralSettings : {'distances': [1], 'additionalInfo': True, 'enableCExtensions': True, 'weightingNorm': None, 'force2D': False, 'interpolator': 'sitkBSpline', 'resampledPixelSpacing': None, 'label': 1, 'normalizeScale': 1, 'normalize': False, 'force2Ddimension': 0, 'removeOutliers': None, 'minimumROISize': None, 'binWidth': 25, 'minimumROIDimensions': 1, 'padDistance': 5}\n",
       "\t general_info_ImageHash : 5c9ce3ca174f0f8324aa4d277e0fef82dc5ac566\n",
-      "\t general_info_ImageSpacing : (0.7812499999999999; 0.7812499999999999; 6.499999999999998)\n",
+      "\t general_info_ImageSpacing : (0.7812499999999999, 0.7812499999999999, 6.499999999999998)\n",
       "\t general_info_InputImages : {'Original': {}}\n",
       "\t general_info_MaskHash : 9dc2c3137b31fd872997d92c9a92d5178126d9d3\n",
-      "\t general_info_Version : v1.0.1.post69.dev0+gc00bfe2\n",
+      "\t general_info_Version : 1.1.1.post18.dev0+g6e387f2\n",
       "\t general_info_VolumeNum : 2\n",
       "\t general_info_VoxelNum : 4137\n",
-      "\t original_shape_Maximum3DDiameter : 65.5366145873\n",
-      "\t original_shape_Compactness2 : 0.114127701901\n",
+      "\t original_shape_SphericalDisproportion : 2.06159321347\n",
       "\t original_shape_Maximum2DDiameterSlice : 47.2187913633\n",
       "\t original_shape_Sphericity : 0.485061744222\n",
-      "\t original_shape_Compactness1 : 26.7546787215\n",
       "\t original_shape_Elongation : 1.7789885567\n",
       "\t original_shape_SurfaceVolumeRatio : 0.392308261863\n",
       "\t original_shape_Volume : 16412.6586914\n",
+      "\t original_shape_Maximum3DDiameter : 65.5366145873\n",
       "\t original_shape_Flatness : 1.21918505897\n",
-      "\t original_shape_SphericalDisproportion : 2.06159321347\n",
-      "\t original_shape_Roundness : 0.61469066615\n",
       "\t original_shape_SurfaceArea : 6438.82160378\n",
       "\t original_shape_Maximum2DDiameterColumn : 44.5487904052\n",
       "\t original_shape_Maximum2DDiameterRow : 61.5801767135\n",
@@ -370,12 +352,12 @@
       "\t original_firstorder_Skewness : 0.275650859086\n",
       "\t original_firstorder_Uniformity : 0.0451569635559\n",
       "\t original_firstorder_MeanAbsoluteDeviation : 133.447261953\n",
-      "\t original_firstorder_Energy : 33122817481.0\n",
+      "\t original_firstorder_Energy : 2918821481.0\n",
       "\t original_firstorder_RobustMeanAbsoluteDeviation : 103.00138343\n",
       "\t original_firstorder_Median : 812.0\n",
-      "\t original_firstorder_TotalEnergy : 131407662126.0\n",
+      "\t original_firstorder_TotalEnergy : 11579797135.3\n",
       "\t original_firstorder_Maximum : 1266.0\n",
-      "\t original_firstorder_RootMeanSquared : 2829.57282108\n",
+      "\t original_firstorder_RootMeanSquared : 839.964644818\n",
       "\t original_firstorder_90Percentile : 1044.4\n",
       "\t original_firstorder_Minimum : 468.0\n",
       "\t original_firstorder_Entropy : 4.6019355539\n",
@@ -430,21 +412,21 @@
       "\t original_glrlm_HighGrayLevelRunEmphasis : 281.066493909\n",
       "\t original_glrlm_RunLengthNonUniformityNormalized : 0.895049465948\n",
       "\t original_glszm_GrayLevelVariance : 40.6031399239\n",
-      "\t original_glszm_LowIntensityLargeAreaEmphasis : 0.127238415533\n",
-      "\t original_glszm_HighIntensitySmallAreaEmphasis : 193.438051926\n",
-      "\t original_glszm_SmallAreaEmphasis : 0.656447899959\n",
+      "\t original_glszm_SmallAreaHighGrayLevelEmphasis : 193.438051926\n",
+      "\t original_glszm_GrayLevelNonUniformityNormalized : 0.0440573079013\n",
+      "\t original_glszm_SizeZoneNonUniformityNormalized : 0.399784380451\n",
+      "\t original_glszm_SizeZoneNonUniformity : 747.596791444\n",
+      "\t original_glszm_GrayLevelNonUniformity : 82.3871657754\n",
       "\t original_glszm_LargeAreaEmphasis : 13.6155080214\n",
       "\t original_glszm_ZoneVariance : 8.72123909749\n",
-      "\t original_glszm_SizeZoneVariabilityNormalized : 0.399784380451\n",
-      "\t original_glszm_LowIntensitySmallAreaEmphasis : 0.0064169820551\n",
-      "\t original_glszm_HighIntensityEmphasis : 288.623529412\n",
-      "\t original_glszm_IntensityVariabilityNormalized : 0.0440573079013\n",
       "\t original_glszm_ZonePercentage : 0.4520183708\n",
-      "\t original_glszm_LowIntensityEmphasis : 0.00910094202771\n",
-      "\t original_glszm_SizeZoneVariability : 747.596791444\n",
-      "\t original_glszm_IntensityVariability : 82.3871657754\n",
+      "\t original_glszm_LargeAreaLowGrayLevelEmphasis : 0.127238415533\n",
+      "\t original_glszm_LargeAreaHighGrayLevelEmphasis : 3514.76149733\n",
+      "\t original_glszm_HighGrayLevelZoneEmphasis : 288.623529412\n",
+      "\t original_glszm_SmallAreaEmphasis : 0.656447899959\n",
+      "\t original_glszm_LowGrayLevelZoneEmphasis : 0.00910094202771\n",
       "\t original_glszm_ZoneEntropy : 6.5082149862\n",
-      "\t original_glszm_HighIntensityLargeAreaEmphasis : 3514.76149733\n"
+      "\t original_glszm_SmallAreaLowGrayLevelEmphasis : 0.0064169820551\n"
      ]
     }
    ],
@@ -466,7 +448,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/bin/Notebooks/helloFeatureClass.ipynb
+++ b/bin/Notebooks/helloFeatureClass.ipynb
@@ -44,11 +44,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
+    "If the repository is available locally, the test case are also availale (located in pyradiomics/data) and therefore do not need to be downloaded. Otherwise, test cases can be downloaded to temporary files. This is handled by the `radiomics.getTestCase()` function, which checks if the requested test case is available and if not, downloads it. It returns a tuple with the location of the image and mask of the requested test case, or (None, None) if it fails.\n",
     "\n",
-    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (\"..\") and then move into the data folders (\"data\").\n",
+    "If the repository is not available locally, `repositoryRoot` will most likely point to an invalid directory, or to a directory which does not contain the test case. In this case, PyRadiomics recognizes this and will revert to downloading test cases or, if already downloaded, the test case in the temporary files.\n",
     "\n",
-    "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
+    "If getting the test case fails, PyRadiomics will log an error explaining the cause."
    ]
   },
   {
@@ -59,15 +59,14 @@
    },
    "outputs": [],
    "source": [
-    "testCase = 'brain1'\n",
-    "dataDir = os.path.join(os.path.abspath(\"\"), \"..\", \"..\", \"data\")\n",
-    "imageName = os.path.join(dataDir, testCase + '_image.nrrd')\n",
-    "maskName = os.path.join(dataDir, testCase + '_label.nrrd')\n",
+    "# repositoryRoot points to the root of the repository. The following line gets that location if this Notebook is run\n",
+    "# from it's default location in \\pyradiomics\\bin\\Notebooks\n",
+    "repositoryRoot = os.path.abspath(os.path.join(os.getcwd(), \"..\", \"..\"))\n",
     "\n",
-    "if not os.path.exists(imageName):\n",
-    "  print('Error: problem finding input image', imageName)\n",
-    "if not os.path.exists(maskName):\n",
-    "  print('Error: problem finding input labelmap', maskName)"
+    "imageName, maskName = radiomics.getTestCase('brain1', repositoryRoot)\n",
+    "\n",
+    "if imageName is None or maskName is None:  # Something went wrong, in this case PyRadiomics will also log an error\n",
+    "    print('Error getting testcase!')"
    ]
   },
   {

--- a/bin/Notebooks/helloRadiomics.ipynb
+++ b/bin/Notebooks/helloRadiomics.ipynb
@@ -99,11 +99,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Testing data is contained in the pyradiomics/data folder, while this file is in the pyradiomics/bin/Notebooks folder. \n",
+    "If the repository is available locally, the test case are also availale (located in pyradiomics/data) and therefore do not need to be downloaded. Otherwise, test cases can be downloaded to temporary files. This is handled by the `radiomics.getTestCase()` function, which checks if the requested test case is available and if not, downloads it. It returns a tuple with the location of the image and mask of the requested test case, or (None, None) if it fails.\n",
     "\n",
-    "The next line of code gets the location of the current path and gets the location of the data as a relative path by going up two folders (\"..\") and then move into the data folders (\"data\").\n",
+    "If the repository is not available locally, `repositoryRoot` will most likely point to an invalid directory, or to a directory which does not contain the test case. In this case, PyRadiomics recognizes this and will revert to downloading test cases or, if already downloaded, the test case in the temporary files.\n",
     "\n",
-    "For this to work, the current active directory should be pyradiomics/bin/notebooks, which is the case if this file is run from the pyradiomics/bin/Notebooks folder."
+    "If getting the test case fails, PyRadiomics will log an error explaining the cause."
    ]
   },
   {
@@ -114,15 +114,14 @@
    },
    "outputs": [],
    "source": [
-    "testCase = 'brain1'\n",
-    "dataDir = os.path.join(os.path.abspath(\"\"), \"..\", \"..\", \"data\")\n",
-    "imageName = os.path.join(dataDir, testCase + '_image.nrrd')\n",
-    "maskName = os.path.join(dataDir, testCase + '_label.nrrd')\n",
+    "# repositoryRoot points to the root of the repository. The following line gets that location if this Notebook is run\n",
+    "# from it's default location in \\pyradiomics\\bin\\Notebooks\n",
+    "repositoryRoot = os.path.abspath(os.path.join(os.getcwd(), \"..\", \"..\"))\n",
     "\n",
-    "if not os.path.exists(imageName):\n",
-    "  print('Error: problem finding input image', imageName)\n",
-    "if not os.path.exists(maskName):\n",
-    "  print('Error: problem finding input labelmap', maskName)"
+    "imageName, maskName = radiomics.getTestCase('brain1', repositoryRoot)\n",
+    "\n",
+    "if imageName is None or maskName is None:  # Something went wrong, in this case PyRadiomics will also log an error\n",
+    "    print('Error getting testcase!')"
    ]
   },
   {
@@ -315,8 +314,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
+    "collapsed": true
    },
    "outputs": [
     {
@@ -880,11 +878,11 @@
    "source": [
     "print(\"Active features:\")\n",
     "for cls, features in six.iteritems(extractor.enabledFeatures):\n",
-    "  if len(features) == 0:\n",
-    "    features = extractor.getFeatureNames(cls)\n",
-    "  for f in features:\n",
-    "    print(f)\n",
-    "    print(getattr(extractor.featureClasses[cls], 'get%sFeatureValue' % f).__doc__)"
+    "    if len(features) == 0:\n",
+    "        features = extractor.getFeatureNames(cls)\n",
+    "    for f in features:\n",
+    "        print(f)\n",
+    "        print(getattr(extractor.featureClasses[cls], 'get%sFeatureValue' % f).__doc__)"
    ]
   },
   {
@@ -1001,7 +999,7 @@
    "source": [
     "# Show output\n",
     "for featureName in featureVector.keys():\n",
-    "  print(\"Computed %s: %s\" % (featureName, featureVector[featureName]))"
+    "    print(\"Computed %s: %s\" % (featureName, featureVector[featureName]))"
    ]
   }
  ],

--- a/bin/helloFeatureClass.py
+++ b/bin/helloFeatureClass.py
@@ -7,21 +7,22 @@ import numpy
 import SimpleITK as sitk
 import six
 
-from radiomics import firstorder, glcm, glrlm, glszm, imageoperations, shape
+from radiomics import firstorder, getTestCase, glcm, glrlm, glszm, imageoperations, shape
 
 # testBinWidth = 25 this is the default bin size
 # testResampledPixelSpacing = [3,3,3] no resampling for now.
 
-testCase = 'brain1'
-dataDir = os.path.join(os.path.abspath(""), "..", "data")
-imageName = os.path.join(dataDir, testCase + '_image.nrrd')
-maskName = os.path.join(dataDir, testCase + '_label.nrrd')
+# Get some test data
 
-if not os.path.exists(imageName):
-  print('Error: problem finding input image', imageName)
-  exit()
-if not os.path.exists(maskName):
-  print('Error: problem finding input image', maskName)
+# repositoryRoot points to the root of the repository. The following line gets that location if this script is run
+# from it's default location in \pyradiomics\bin. Otherwise, it will point to some (invalid) folder, causing the
+# getTestCase function to fail to find the test case in the repository. In that case, a test case will be downloaded to
+# temporary files and it's location is returned.
+repositoryRoot = os.path.abspath(os.path.join(os.getcwd(), ".."))
+imageName, maskName = getTestCase('brain1', repositoryRoot)
+
+if imageName is None or maskName is None:  # Something went wrong, in this case PyRadiomics will also log an error
+  print('Error getting testcase!')
   exit()
 
 image = sitk.ReadImage(imageName)

--- a/bin/helloRadiomics.py
+++ b/bin/helloRadiomics.py
@@ -66,17 +66,17 @@ def clickProgressbar():
 
   radiomics.progressReporter = progressWrapper
 
+# Get some test data
 
-testCase = 'brain1'
-dataDir = os.path.join(os.path.abspath(""), "..", "data")
-imageName = os.path.join(dataDir, testCase + '_image.nrrd')
-maskName = os.path.join(dataDir, testCase + '_label.nrrd')
+# repositoryRoot points to the root of the repository. The following line gets that location if this script is run
+# from it's default location in \pyradiomics\bin. Otherwise, it will point to some (invalid) folder, causing the
+# getTestCase function to fail to find the test case in the repository. In that case, a test case will be downloaded to
+# temporary files and it's location is returned.
+repositoryRoot = os.path.abspath(os.path.join(os.getcwd(), ".."))
+imageName, maskName = radiomics.getTestCase('brain1', repositoryRoot)
 
-if not os.path.exists(imageName):
-  print('Error: problem finding input image', imageName)
-  exit()
-if not os.path.exists(maskName):
-  print('Error: problem finding input labelmap', maskName)
+if imageName is None or maskName is None:  # Something went wrong, in this case PyRadiomics will also log an error
+  print('Error getting testcase!')
   exit()
 
 # Uncomment line below to output debug and info log messaging to stderr


### PR DESCRIPTION
This function is available in the radiomics namespace and takes the test case name as an argument. Optionally the location of the repository can also be specified, in which case the test files of the repository are used.
If test files cannot be found, the are downloaded from github and stored in a temporary folder.

This function returns a tuple of 2 strings representing the paths to the (downloaded) image and segmentation files.

TODO:
 - [x] Add documentation to this function
 - [x] Test the function
 - [x] Incorporate function in PyRadiomics Notebooks
 - [x] Add logging calls in the function