### PR TITLE
Define return values for 0-division errors etc

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -306,7 +306,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     i = self.coefficients['i']
     j = self.coefficients['j']
     ac = numpy.sum(self.P_glcm * (i * j)[:, :, None], (0, 1))
-    return (ac.mean())
+    return ac.mean()
 
   def getAverageIntensityFeatureValue(self):
     r"""
@@ -344,7 +344,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     ux = self.coefficients['ux']
     uy = self.coefficients['uy']
     cp = numpy.sum((self.P_glcm * (((i + j)[:, :, None] - ux - uy) ** 4)), (0, 1))
-    return (cp.mean())
+    return cp.mean()
 
   def getClusterShadeFeatureValue(self):
     r"""
@@ -363,7 +363,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     ux = self.coefficients['ux']
     uy = self.coefficients['uy']
     cs = numpy.sum((self.P_glcm * (((i + j)[:, :, None] - ux - uy) ** 3)), (0, 1))
-    return (cs.mean())
+    return cs.mean()
 
   def getClusterTendencyFeatureValue(self):
     r"""
@@ -381,7 +381,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     ux = self.coefficients['ux']
     uy = self.coefficients['uy']
     ct = numpy.sum((self.P_glcm * (((i + j)[:, :, None] - ux - uy) ** 2)), (0, 1))
-    return (ct.mean())
+    return ct.mean()
 
   def getContrastFeatureValue(self):
     r"""
@@ -397,7 +397,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     i = self.coefficients['i']
     j = self.coefficients['j']
     cont = numpy.sum((self.P_glcm * ((numpy.abs(i - j))[:, :, None] ** 2)), (0, 1))
-    return (cont.mean())
+    return cont.mean()
 
   def getCorrelationFeatureValue(self):
     r"""
@@ -413,8 +413,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     .. note::
 
       When there is only 1 discreet gray value in the ROI (flat region), :math:`\sigma_x` and :math:`\sigma_y` will be
-      0. In this case, the value of correlation will be a NaN.
+      0. In this case, an arbitrary value of 1 is returned instead. This is assessed on a per-angle basis.
     """
+    eps = self.coefficients['eps']
     i = self.coefficients['i']
     j = self.coefficients['j']
     ux = self.coefficients['ux']
@@ -422,12 +423,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     sigx = self.coefficients['sigx']
     sigy = self.coefficients['sigy']
 
-    try:
-      corm = numpy.sum(self.P_glcm * (i[:, :, None] - ux) * (j[:, :, None] - uy), (0, 1), keepdims=True)
-      corr = corm / (sigx * sigy)
-      return (corr.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    corm = numpy.sum(self.P_glcm * (i[:, :, None] - ux) * (j[:, :, None] - uy), (0, 1), keepdims=True)
+    corr = corm / (sigx * sigy + eps)
+    corr[sigx * sigy == 0] = 1  # Set elements that would be divided by 0 to 1.
+    return corr.mean()
 
   def getDifferenceAverageFeatureValue(self):
     r"""
@@ -444,7 +443,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     pxSuby = self.coefficients['pxSuby']
     kValuesDiff = self.coefficients['kValuesDiff']
     diffavg = numpy.sum((kValuesDiff[:, None] * pxSuby), 0)
-    return (diffavg.mean())
+    return diffavg.mean()
 
   def getDifferenceEntropyFeatureValue(self):
     r"""
@@ -460,7 +459,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     pxSuby = self.coefficients['pxSuby']
     eps = self.coefficients['eps']
     difent = (-1) * numpy.sum((pxSuby * numpy.log2(pxSuby + eps)), 0)
-    return (difent.mean())
+    return difent.mean()
 
   def getDifferenceVarianceFeatureValue(self):
     r"""
@@ -477,7 +476,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     kValuesDiff = self.coefficients['kValuesDiff']
     diffavg = numpy.sum((kValuesDiff[:, None] * pxSuby), 0, keepdims=True)
     diffvar = numpy.sum((pxSuby * ((kValuesDiff[:, None] - diffavg) ** 2)), 0)
-    return (diffvar.mean())
+    return diffvar.mean()
 
   def getDissimilarityFeatureValue(self):
     r"""
@@ -494,7 +493,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     i = self.coefficients['i']
     j = self.coefficients['j']
     dis = numpy.sum((self.P_glcm * (numpy.abs(i - j))[:, :, None]), (0, 1))
-    return (dis.mean())
+    return dis.mean()
 
   def getEnergyFeatureValue(self):
     r"""
@@ -510,7 +509,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     higher frequencies.
     """
     ene = numpy.sum((self.P_glcm ** 2), (0, 1))
-    return (ene.mean())
+    return ene.mean()
 
   def getEntropyFeatureValue(self):
     r"""
@@ -524,7 +523,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     Entropy is a measure of the randomness/variability in neighborhood intensity values.
     """
     ent = self.coefficients['HXY']
-    return (ent.mean())
+    return ent.mean()
 
   def getHomogeneity1FeatureValue(self):
     r"""
@@ -541,7 +540,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     i = self.coefficients['i']
     j = self.coefficients['j']
     homo1 = numpy.sum((self.P_glcm / (1 + (numpy.abs(i - j))[:, :, None])), (0, 1))
-    return (homo1.mean())
+    return homo1.mean()
 
   def getHomogeneity2FeatureValue(self):
     r"""
@@ -557,7 +556,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     i = self.coefficients['i']
     j = self.coefficients['j']
     homo2 = numpy.sum((self.P_glcm / (1 + (numpy.abs(i - j))[:, :, None] ** 2)), (0, 1))
-    return (homo2.mean())
+    return homo2.mean()
 
   def getImc1FeatureValue(self):
     r"""
@@ -566,13 +565,24 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     .. math::
 
       \textit{IMC 1} = \frac{HXY-HXY1}{\max\{HX,HY\}}
+
+    .. note::
+
+      In the case where both HX and HY are 0 (as is the case in a flat region), an arbitrary value of 0 is returned to
+      prevent a division by 0. This is done on a per-angle basis
     """
+    eps = self.coefficients['eps']
     HX = self.coefficients['HX']
     HY = self.coefficients['HY']
     HXY = self.coefficients['HXY']
     HXY1 = self.coefficients['HXY1']
-    imc1 = (HXY - HXY1) / numpy.max(([HX, HY]), 0)
-    return (imc1.mean())
+
+    div = numpy.max(([HX, HY]), 0)
+
+    imc1 = (HXY - HXY1) / (div + eps)
+    imc1[div == 0] = 0  # Set elements that would be divided by 0 to 0
+
+    return imc1.mean()
 
   def getImc2FeatureValue(self):
     r"""
@@ -581,13 +591,19 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     .. math::
 
       \textit{IMC 2} = \sqrt{1-e^{-2(HXY2-HXY)}}
+
+    .. note::
+
+      In the case where HXY = HXY2, an arbitrary value of 0 is returned to prevent returning complex numbers. This is
+      done on a per-angle basis.
     """
     HXY = self.coefficients['HXY']
     HXY2 = self.coefficients['HXY2']
 
-    imc2 = (1 - numpy.e ** (-2 * (HXY2 - HXY))) ** (0.5)  # matlab:(1-exp(-2*(hxy2-hxy)))^0.5;
+    imc2 = (1 - numpy.e ** (-2 * (HXY2 - HXY))) ** 0.5
+    imc2[HXY2 == HXY] = 0
 
-    return (imc2.mean())
+    return imc2.mean()
 
   def getIdmFeatureValue(self):
     r"""
@@ -603,8 +619,8 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     i = self.coefficients['i']
     j = self.coefficients['j']
-    idm = numpy.sum((self.P_glcm / (1 + (((numpy.abs(i - j))[:, :, None] ** 2)))), (0, 1))
-    return (idm.mean())
+    idm = numpy.sum((self.P_glcm / (1 + ((numpy.abs(i - j))[:, :, None] ** 2))), (0, 1))
+    return idm.mean()
 
   def getIdmnFeatureValue(self):
     r"""
@@ -626,7 +642,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     j = self.coefficients['j']
     Ng = self.coefficients['Ng']
     idmn = numpy.sum((self.P_glcm / (1 + (((numpy.abs(i - j))[:, :, None] ** 2) / (Ng ** 2)))), (0, 1))
-    return (idmn.mean())
+    return idmn.mean()
 
   def getIdFeatureValue(self):
     r"""
@@ -641,8 +657,8 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     """
     i = self.coefficients['i']
     j = self.coefficients['j']
-    id = numpy.sum((self.P_glcm / (1 + ((numpy.abs(i - j))[:, :, None]))), (0, 1))
-    return (id.mean())
+    invDiff = numpy.sum((self.P_glcm / (1 + ((numpy.abs(i - j))[:, :, None]))), (0, 1))
+    return invDiff.mean()
 
   def getIdnFeatureValue(self):
     r"""
@@ -662,7 +678,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     j = self.coefficients['j']
     Ng = self.coefficients['Ng']
     idn = numpy.sum((self.P_glcm / (1 + ((numpy.abs(i - j))[:, :, None] / Ng))), (0, 1))
-    return (idn.mean())
+    return idn.mean()
 
   def getInverseVarianceFeatureValue(self):
     r"""
@@ -677,7 +693,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     j = self.coefficients['j']
     maskDiags = numpy.abs(i - j) > 0
     inv = numpy.sum((self.P_glcm[maskDiags] / ((numpy.abs(i - j))[:, :, None] ** 2)[maskDiags]), 0)
-    return (inv.mean())
+    return inv.mean()
 
   def getMaximumProbabilityFeatureValue(self):
     r"""
@@ -691,7 +707,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     neighboring intensity values.
     """
     maxprob = self.P_glcm.max((0, 1))
-    return (maxprob.mean())
+    return maxprob.mean()
 
   def getSumAverageFeatureValue(self):
     r"""
@@ -708,7 +724,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     pxAddy = self.coefficients['pxAddy']
     kValuesSum = self.coefficients['kValuesSum']
     sumavg = numpy.sum((kValuesSum[:, None] * pxAddy), 0)
-    return (sumavg.mean())
+    return sumavg.mean()
 
   def getSumEntropyFeatureValue(self):
     r"""
@@ -723,7 +739,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     pxAddy = self.coefficients['pxAddy']
     eps = self.coefficients['eps']
     sumentr = (-1) * numpy.sum((pxAddy * numpy.log2(pxAddy + eps)), 0)
-    return (sumentr.mean())
+    return sumentr.mean()
 
   def getSumVarianceFeatureValue(self):
     r"""
@@ -740,7 +756,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     kValuesSum = self.coefficients['kValuesSum']
     sumavg = numpy.sum((kValuesSum[:, None] * pxAddy), 0, keepdims=True)
     sumvar = numpy.sum((pxAddy * ((kValuesSum[:, None] - sumavg) ** 2)), 0)
-    return (sumvar.mean())
+    return sumvar.mean()
 
   def getSumSquaresFeatureValue(self):
     r"""
@@ -763,4 +779,4 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     ux = self.coefficients['ux']
     # Also known as Variance
     ss = numpy.sum((self.P_glcm * ((i[:, :, None] - ux) ** 2)), (0, 1))
-    return (ss.mean())
+    return ss.mean()

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -266,7 +266,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     try:
       sre = numpy.sum((pr / (jvector[:, None] ** 2)), 0) / sumP_glrlm
-      return (sre.mean())
+      return sre.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -288,7 +288,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     try:
       lre = numpy.sum((pr * (jvector[:, None] ** 2)), 0) / sumP_glrlm
-      return (lre.mean())
+      return lre.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -309,7 +309,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     try:
       gln = numpy.sum((pg ** 2), 0) / sumP_glrlm
-      return (gln.mean())
+      return gln.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -351,7 +351,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     try:
       rln = numpy.sum((pr ** 2), 0) / sumP_glrlm
-      return (rln.mean())
+      return rln.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -372,7 +372,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     try:
       rlnn = numpy.sum((pr ** 2), 0) / sumP_glrlm ** 2
-      return (rlnn.mean())
+      return rlnn.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -392,8 +392,8 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Np = self.coefficients['Np']
 
     try:
-      rp = numpy.sum((self.P_glrlm / (Np)), (0, 1))
-      return (rp.mean())
+      rp = numpy.sum((self.P_glrlm / Np), (0, 1))
+      return rp.mean()
     except ZeroDivisionError:
       return numpy.core.nan
 
@@ -468,11 +468,8 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     ivector = self.coefficients['ivector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      lglre = numpy.sum((pg / (ivector[:, None] ** 2)), 0) / sumP_glrlm
-      return (lglre.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    lglre = numpy.sum((pg / (ivector[:, None] ** 2)), 0) / sumP_glrlm
+    return lglre.mean()
 
   def getHighGrayLevelRunEmphasisFeatureValue(self):
     r"""
@@ -490,11 +487,8 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     ivector = self.coefficients['ivector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      hglre = numpy.sum((pg * (ivector[:, None] ** 2)), 0) / sumP_glrlm
-      return (hglre.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    hglre = numpy.sum((pg * (ivector[:, None] ** 2)), 0) / sumP_glrlm
+    return hglre.mean()
 
   def getShortRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -511,12 +505,9 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     jvector = self.coefficients['jvector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      srlgle = numpy.sum((self.P_glrlm / ((ivector[:, None, None] ** 2) * (jvector[None, :, None] ** 2))),
-                         (0, 1)) / sumP_glrlm
-      return (srlgle.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    srlgle = numpy.sum((self.P_glrlm / ((ivector[:, None, None] ** 2) * (jvector[None, :, None] ** 2))),
+                       (0, 1)) / sumP_glrlm
+    return srlgle.mean()
 
   def getShortRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -533,12 +524,9 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     jvector = self.coefficients['jvector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      srhgle = numpy.sum((self.P_glrlm * (ivector[:, None, None] ** 2) / (jvector[None, :, None] ** 2)),
-                         (0, 1)) / sumP_glrlm
-      return (srhgle.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    srhgle = numpy.sum((self.P_glrlm * (ivector[:, None, None] ** 2) / (jvector[None, :, None] ** 2)),
+                       (0, 1)) / sumP_glrlm
+    return srhgle.mean()
 
   def getLongRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -555,12 +543,9 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     jvector = self.coefficients['jvector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      lrlgle = numpy.sum((self.P_glrlm * (jvector[None, :, None] ** 2) / (ivector[:, None, None] ** 2)),
-                         (0, 1)) / sumP_glrlm
-      return (lrlgle.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    lrlgle = numpy.sum((self.P_glrlm * (jvector[None, :, None] ** 2) / (ivector[:, None, None] ** 2)),
+                       (0, 1)) / sumP_glrlm
+    return lrlgle.mean()
 
   def getLongRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -577,9 +562,6 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     jvector = self.coefficients['jvector']
     sumP_glrlm = self.coefficients['sumP_glrlm']
 
-    try:
-      lrhgle = numpy.sum((self.P_glrlm * ((jvector[None, :, None] ** 2) * (ivector[:, None, None] ** 2))),
-                         (0, 1)) / sumP_glrlm
-      return (lrhgle.mean())
-    except ZeroDivisionError:
-      return numpy.core.nan
+    lrhgle = numpy.sum((self.P_glrlm * ((jvector[None, :, None] ** 2) * (ivector[:, None, None] ** 2))),
+                       (0, 1)) / sumP_glrlm
+    return lrhgle.mean()

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -190,7 +190,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       sae = numpy.sum(self.coefficients['pr'] / (self.coefficients['jvector'] ** 2)) / self.coefficients['sumP_glszm']
     except ZeroDivisionError:
       sae = numpy.core.numeric.NaN
-    return (sae)
+    return sae
 
   def getLargeAreaEmphasisFeatureValue(self):
     r"""
@@ -208,7 +208,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       lae = numpy.sum(self.coefficients['pr'] * (self.coefficients['jvector'] ** 2)) / self.coefficients['sumP_glszm']
     except ZeroDivisionError:
       lae = numpy.core.numeric.NaN
-    return (lae)
+    return lae
 
   def getGrayLevelNonUniformityFeatureValue(self):
     r"""
@@ -226,7 +226,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       iv = numpy.sum(self.coefficients['pg'] ** 2) / self.coefficients['sumP_glszm']
     except ZeroDivisionError:
       iv = numpy.core.numeric.NaN
-    return (iv)
+    return iv
 
   def getGrayLevelNonUniformityNormalizedFeatureValue(self):
     r"""
@@ -244,7 +244,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       ivn = numpy.sum(self.coefficients['pg'] ** 2) / self.coefficients['sumP_glszm'] ** 2
     except ZeroDivisionError:
       ivn = numpy.core.numeric.NaN
-    return (ivn)
+    return ivn
 
   def getSizeZoneNonUniformityFeatureValue(self):
     r"""
@@ -262,7 +262,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       szv = numpy.sum(self.coefficients['pr'] ** 2) / self.coefficients['sumP_glszm']
     except ZeroDivisionError:
       szv = numpy.core.numeric.NaN
-    return (szv)
+    return szv
 
   def getSizeZoneNonUniformityNormalizedFeatureValue(self):
     r"""
@@ -280,7 +280,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       szvn = numpy.sum(self.coefficients['pr'] ** 2) / self.coefficients['sumP_glszm'] ** 2
     except ZeroDivisionError:
       szvn = numpy.core.numeric.NaN
-    return (szvn)
+    return szvn
 
   def getZonePercentageFeatureValue(self):
     r"""
@@ -299,7 +299,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       zp = self.coefficients['sumP_glszm'] / self.coefficients['Np']
     except ZeroDivisionError:
       zp = numpy.core.numeric.NaN
-    return (zp)
+    return zp
 
   def getGrayLevelVarianceFeatureValue(self):
     r"""
@@ -367,11 +367,8 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     LGLZE measures the distribution of lower gray-level size zones, with a higher value indicating a greater proportion
     of lower gray-level values and size zones in the image.
     """
-    try:
-      lie = numpy.sum((self.coefficients['pg'] / (self.coefficients['ivector'] ** 2))) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      lie = numpy.core.numeric.NaN
-    return (lie)
+    lie = numpy.sum((self.coefficients['pg'] / (self.coefficients['ivector'] ** 2))) / self.coefficients['sumP_glszm']
+    return lie
 
   def getHighGrayLevelZoneEmphasisFeatureValue(self):
     r"""
@@ -385,11 +382,8 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     HGLZE measures the distribution of the higher gray-level values, with a higher value indicating a greater proportion
     of higher gray-level values and size zones in the image.
     """
-    try:
-      hie = numpy.sum((self.coefficients['pg'] * (self.coefficients['ivector'] ** 2))) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      hie = numpy.core.numeric.NaN
-    return (hie)
+    hie = numpy.sum((self.coefficients['pg'] * (self.coefficients['ivector'] ** 2))) / self.coefficients['sumP_glszm']
+    return hie
 
   def getSmallAreaLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -403,13 +397,10 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     SALGLE measures the proportion in the image of the joint distribution of smaller size zones with lower gray-level
     values.
     """
-    try:
-      lisae = numpy.sum(
-        (self.P_glszm / ((self.coefficients['ivector'][:, None] ** 2) * (self.coefficients['jvector'][None, :] ** 2))),
-        (0, 1)) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      lisae = numpy.core.numeric.NaN
-    return (lisae)
+    lisae = numpy.sum(
+      (self.P_glszm / ((self.coefficients['ivector'][:, None] ** 2) * (self.coefficients['jvector'][None, :] ** 2))),
+      (0, 1)) / self.coefficients['sumP_glszm']
+    return lisae
 
   def getSmallAreaHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -423,13 +414,10 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     SAHGLE measures the proportion in the image of the joint distribution of smaller size zones with higher gray-level
     values.
     """
-    try:
-      hisae = numpy.sum(
-        (self.P_glszm * (self.coefficients['ivector'][:, None] ** 2) / (self.coefficients['jvector'][None, :] ** 2)),
-        (0, 1)) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      hisae = numpy.core.numeric.NaN
-    return (hisae)
+    hisae = numpy.sum(
+      (self.P_glszm * (self.coefficients['ivector'][:, None] ** 2) / (self.coefficients['jvector'][None, :] ** 2)),
+      (0, 1)) / self.coefficients['sumP_glszm']
+    return hisae
 
   def getLargeAreaLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -443,13 +431,10 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     LALGLE measures the proportion in the image of the joint distribution of larger size zones with lower gray-level
     values.
     """
-    try:
-      lilae = numpy.sum(
-        (self.P_glszm * (self.coefficients['jvector'][None, :] ** 2) / (self.coefficients['ivector'][:, None] ** 2)),
-        (0, 1)) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      lilae = numpy.core.numeric.NaN
-    return (lilae)
+    lilae = numpy.sum(
+      (self.P_glszm * (self.coefficients['jvector'][None, :] ** 2) / (self.coefficients['ivector'][:, None] ** 2)),
+      (0, 1)) / self.coefficients['sumP_glszm']
+    return lilae
 
   def getLargeAreaHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -463,10 +448,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     LAHGLE measures the proportion in the image of the joint distribution of larger size zones with higher gray-level
     values.
     """
-    try:
-      hilae = numpy.sum(
-        (self.P_glszm * ((self.coefficients['jvector'][None, :] ** 2) * (self.coefficients['ivector'][:, None] ** 2))),
-        (0, 1)) / self.coefficients['sumP_glszm']
-    except ZeroDivisionError:
-      hilae = numpy.core.numeric.NaN
-    return (hilae)
+    hilae = numpy.sum(
+      (self.P_glszm * ((self.coefficients['jvector'][None, :] ** 2) * (self.coefficients['ivector'][:, None] ** 2))),
+      (0, 1)) / self.coefficients['sumP_glszm']
+    return hilae

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -202,7 +202,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     - Lorensen WE, Cline HE. Marching cubes: A high resolution 3D surface construction algorithm. ACM SIGGRAPH Comput
       Graph `Internet <http://portal.acm.org/citation.cfm?doid=37402.37422>`_. 1987;21:163-9.
     """
-    return (self.SurfaceArea)
+    return self.SurfaceArea
 
   def getSurfaceVolumeRatioFeatureValue(self):
     r"""
@@ -215,7 +215,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     Here, a lower value indicates a more compact (sphere-like) shape. This feature is not dimensionless, and is
     therefore (partly) dependent on the volume of the ROI.
     """
-    return (self.SurfaceArea / self.Volume)
+    return self.SurfaceArea / self.Volume
 
   def getSphericityFeatureValue(self):
     r"""
@@ -260,7 +260,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
       parameter file provided in the ``pyradiomics/examples/exampleSettings`` folder, Compactness 1 and Compactness 2
       are therefore disabled.
     """
-    return ((self.Volume) / ((self.SurfaceArea) ** (3.0 / 2.0) * numpy.sqrt(numpy.pi)))
+    return self.Volume / (self.SurfaceArea ** (3.0 / 2.0) * numpy.sqrt(numpy.pi))
 
   def getCompactness2FeatureValue(self):
     r"""
@@ -282,7 +282,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
       parameter file provided in the ``pyradiomics/examples/exampleSettings`` folder, Compactness 1 and Compactness 2
       are therefore disabled.
     """
-    return ((36.0 * numpy.pi) * ((self.Volume) ** 2.0) / ((self.SurfaceArea) ** 3.0))
+    return (36.0 * numpy.pi) * (self.Volume ** 2.0) / (self.SurfaceArea ** 3.0)
 
   def getSphericalDisproportionFeatureValue(self):
     r"""


### PR DESCRIPTION
For some features the formula would return NaN in specific cases (e.g. a flat region). Document and return predefined values in these cases.