### PR TITLE
Enhance C GLSZM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Feature Calculation Changes
   (`#233 <https://github.com/Radiomics/pyradiomics/pull/233>`_)
 - Redefine features *Elongation* and *Flatness* as the inverse of the original definition. This prevents a returned
   value of NaN when the shape is completely flat. (`#234 <https://github.com/Radiomics/pyradiomics/pull/234>`_)
+- In certain edge cases, the calculated maximum diameters may be too small when calculating using the python
+  implementation. This is corrected by the C extension and a warning is now logged when calculating these features in
+  python. (`#255 <https://github.com/Radiomics/pyradiomics/pull/255>`_)
 
 New Features
 ############
@@ -64,6 +67,12 @@ Internal API
 ############
 
 - Add function to get or download test case (`#235 <https://github.com/Radiomics/pyradiomics/pull/235>`_)
+- Rewrite C Extension algorithm for GSLZM. Instead of searching over the image for the next voxel when
+  growing a region, store all unprocessed voxels in a stack. This yields a significant increase in performance,
+  especially in large ROIs. Requires slightly more memory (1 array, type integer, size equal to number of voxels in
+  the ROI) (`#255 <https://github.com/Radiomics/pyradiomics/pull/255>`_)
+- Implement C extension for calculation of maximum diameters.
+  (`#255 <https://github.com/Radiomics/pyradiomics/pull/255>`_)
 
 Cleanups
 ########

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -297,6 +297,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     Maximum 3D diameter is defined as the largest pairwise Euclidean distance between surface voxels in the ROI.
 
     Also known as Feret Diameter.
+
+    .. warning::
+
+      This feature is only available when C Extensions are enabled
     """
 
     if cMatsEnabled():
@@ -314,6 +318,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     Maximum 2D diameter (Slice) is defined as the largest pairwise Euclidean distance between tumor surface voxels in
     the row-column (generally the axial) plane.
+
+    .. warning::
+
+      This feature is only available when C Extensions are enabled
     """
     if cMatsEnabled():
       if self.diameters is None:
@@ -330,6 +338,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     Maximum 2D diameter (Column) is defined as the largest pairwise Euclidean distance between tumor surface voxels in
     the row-slice (usually the coronal) plane.
+
+    .. warning::
+
+      This feature is only available when C Extensions are enabled
     """
     if cMatsEnabled():
       if self.diameters is None:
@@ -346,6 +358,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     Maximum 2D diameter (Row) is defined as the largest pairwise Euclidean distance between tumor surface voxels in the
     column-slice (usually the sagittal) plane.
+
+    .. warning::
+
+      This feature is only available when C Extensions are enabled
     """
     if cMatsEnabled():
       if self.diameters is None:

--- a/radiomics/src/_cmatrices.c
+++ b/radiomics/src/_cmatrices.c
@@ -181,7 +181,7 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   PyArrayObject *image_arr, *mask_arr, *angles_arr;
   int Sx, Sy, Sz, Na;
   int *image;
-  signed char *mask;
+  char *mask;
   int *angles;
   int *tempData;
   int maxRegion;
@@ -248,7 +248,7 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
 
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
-  mask = (signed char *)PyArray_DATA(mask_arr);
+  mask = (char *)PyArray_DATA(mask_arr);
   angles = (int *)PyArray_DATA(angles_arr);
 
   //Calculate GLSZM

--- a/radiomics/src/_cshape.c
+++ b/radiomics/src/_cshape.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "cshape.h"
@@ -12,12 +13,15 @@ static char module_docstring[] = "This module links to C-compiled code for effic
 static char surface_docstring[] = "Arguments: Mask, PixelSpacing, uses a marching cubes algorithm to calculate an "
                                   "approximation to the total surface area. The isovalue is considered to be situated "
                                   "midway between a voxel that is part of the segmentation and a voxel that is not.";
+static char diameter_docstring[] = "Arguments: Mask, PixelSpacing, Angles, ROI size.";
 
 static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args);
+static PyObject *cshape_calculate_diameter(PyObject *self, PyObject *args);
 
 static PyMethodDef module_methods[] = {
   //{"calculate_", cmatrices_, METH_VARARGS, _docstring},
   { "calculate_surfacearea", cshape_calculate_surfacearea, METH_VARARGS, surface_docstring },
+  { "calculate_diameter", cshape_calculate_diameter,METH_VARARGS, diameter_docstring},
   { NULL, NULL, 0, NULL }
 };
 
@@ -83,7 +87,6 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
   char *mask;
   double *spacing;
   double SA;
-
   // Parse the input tuple
   if (!PyArg_ParseTuple(args, "OO", &mask_obj, &spacing_obj))
     return NULL;
@@ -118,7 +121,7 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
   mask = (char *)PyArray_DATA(mask_arr);
   spacing = (double *)PyArray_DATA(spacing_arr);
 
-  //Calculate GLCM
+  //Calculate Surface Area
   SA = calculate_surfacearea(mask, size, spacing);
 
   // Clean up
@@ -127,9 +130,84 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
 
   if (SA < 0) // if SA < 0, an error has occurred
   {
-    PyErr_SetString(PyExc_RuntimeError, "Calculation of GLCM Failed.");
+    PyErr_SetString(PyExc_RuntimeError, "Calculation of Surface Area Failed.");
     return NULL;
   }
 
   return Py_BuildValue("f", SA);
+}
+
+static PyObject *cshape_calculate_diameter(PyObject *self, PyObject *args)
+{
+  PyObject *mask_obj, *spacing_obj, *angles_obj;
+  PyArrayObject *mask_arr, *spacing_arr, *angles_arr;
+  int Ns, Na;
+  int size[3];
+  char *mask;
+  double *spacing;
+  int *angles;
+  double *diameters;
+  PyObject *rslt;
+
+  // Parse the input tuple
+  if (!PyArg_ParseTuple(args, "OOOi", &mask_obj, &spacing_obj, &angles_obj, &Ns))
+    return NULL;
+
+  // Interpret the input as numpy arrays
+  mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
+  spacing_arr = (PyArrayObject *)PyArray_FROM_OTF(spacing_obj, NPY_DOUBLE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
+  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
+
+  if (mask_arr == NULL || spacing_arr == NULL || angles_arr == NULL)
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    Py_XDECREF(angles_arr);
+    return NULL;
+  }
+
+  if (PyArray_NDIM(mask_arr) != 3)
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    Py_XDECREF(angles_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for image and mask.");
+    return NULL;
+  }
+
+  // Get sizes of the arrays
+  size[2] = (int)PyArray_DIM(mask_arr, 2);
+  size[1] = (int)PyArray_DIM(mask_arr, 1);
+  size[0] = (int)PyArray_DIM(mask_arr, 0);
+
+  Na = (int)PyArray_DIM(angles_arr, 0);
+
+  // Get arrays in Ctype
+  mask = (char *)PyArray_DATA(mask_arr);
+  spacing = (double *)PyArray_DATA(spacing_arr);
+  angles = (int *)PyArray_DATA(angles_arr);
+
+  // Initialize output array (elements not set)
+  diameters = (double *)calloc(4, sizeof(double));
+
+  // Calculating Max 3D Diameter
+  if (!calculate_diameter(mask, size, spacing, angles, Na, Ns, diameters))
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    Py_XDECREF(angles_arr);
+    free(diameters);
+    PyErr_SetString(PyExc_RuntimeError, "Calculation of maximum 3D diameter failed.");
+    return NULL;
+  }
+
+  rslt = Py_BuildValue("ffff", diameters[0], diameters[1], diameters[2], diameters[3]);
+
+  // Clean up
+  Py_XDECREF(mask_arr);
+  Py_XDECREF(spacing_arr);
+  Py_XDECREF(angles_arr);
+  free(diameters);
+
+  return rslt;
 }

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,5 +1,5 @@
 int calculate_glcm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, double *glcm, int Ng);
-int calculate_glszm(int *image, signed char *mask, int Sx, int Sy, int Sz, int *angles, int Na, int *tempData, int Ng, int Ns);
+int calculate_glszm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, int *tempData, int Ng, int Ns);
 int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
 int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int Ng, int Nr);
 int run_diagonal(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int glrlm_idx_max, int Nr, int *jd, int a);

--- a/radiomics/src/cshape.h
+++ b/radiomics/src/cshape.h
@@ -1,2 +1,3 @@
 double calculate_surfacearea(char *mask, int *size, double *spacing);
 void interpolate(double *vertEntry, int a1, int a2, double *spacing);
+int calculate_diameter(char *mask, int *size, double *spacing, int *angles, int Na, int Ns, double *diameters);


### PR DESCRIPTION
Enhance C extension algorithm for calculating GLSZM. Instead of searching over entire image for voxels to process when growing a region, instantiate a stack (max size equal to number of voxels) to hold indices for voxels that have to be processed for the current region.

When an unprocessed voxel, belonging to the ROI is found, a region is started by pushing the index of that voxels to the stack. Then a loop is started where the last added voxel in the stack is popped and its neighbours are checked. If unprocessed and belonging to the same region (same gray level), indices for those voxels are also pushed to the stack. The loop then runs until stack is exhausted (i.e. no new neighbours available, indicating the region is complete). The number of loops are counted and are equal to the size of the zone.

Reset data type for mask from signed char back to char, as negative values are not needed anymore.

Profiling results (from previous to new C extension implementation):
5 test cases, normal mask 56 ms --> 6 ms
brain1 test case, full mask 1340015 ms --> 4855 ms

Performance of GLSZM calculation now comparable to that of GLRLM (approx. 2.5x slower than GLCM)

![profiling_full_mask_new](https://cloud.githubusercontent.com/assets/18026947/26312434/d0160da0-3f07-11e7-8231-34d24e9d7787.jpg)

cc @Radiomics/developers 
Fixes #256 