### PR TITLE
BUG: use resampled mask for analysis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Bug fixes
 - Correct ``Np`` when weighting is applied in GLRLM (`#229 <https://github.com/Radiomics/pyradiomics/pull/229>`_)
 - Update CSV generators to reflect variable number of columns for input CSV in batch processing.
   (`#246 <https://github.com/Radiomics/pyradiomics/pull/246>`_)
+- Return corrected mask when it had to be resampled due to geometry mismatch errors
+  (`#260 <https://github.com/Radiomics/pyradiomics/pull/260>`_)
 
 Requirements
 ############

--- a/bin/addClassToBaseline.py
+++ b/bin/addClassToBaseline.py
@@ -74,7 +74,9 @@ def main():
 
     provenance = extractor.getProvenance(imagePath, maskPath, mask)
 
-    bb = imageoperations.checkMask(image, mask)
+    bb, correctedMask = imageoperations.checkMask(image, mask)
+    if correctedMask is not None:
+      mask = correctedMask
     image, mask = imageoperations.cropToTumorMask(image, mask, bb)
     for cls in newClasses:
       print("\t\tCalculating class", cls)

--- a/examples/helloFeatureClass.py
+++ b/examples/helloFeatureClass.py
@@ -46,7 +46,9 @@ kwargs = {'binWidth': 25,
 if kwargs['interpolator'] is not None and kwargs['resampledPixelSpacing'] is not None:
   image, mask = imageoperations.resampleImage(image, mask, kwargs['resampledPixelSpacing'], kwargs['interpolator'])
 else:
-  bb = imageoperations.checkMask(image, mask)
+  bb, correctedMask = imageoperations.checkMask(image, mask)
+  if correctedMask is not None:
+    mask = correctedMask
   image, mask = imageoperations.cropToTumorMask(image, mask, bb)
 
 #

--- a/notebooks/helloFeatureClass.ipynb
+++ b/notebooks/helloFeatureClass.ipynb
@@ -150,7 +150,9 @@
    "source": [
     "# Crop the image\n",
     "# bb is the bounding box, upon which the image and mask are cropped\n",
-    "bb = imageoperations.checkMask(image, mask, label=1)\n",
+    "bb, correctedMask = imageoperations.checkMask(image, mask, label=1)\n",
+    "if correctedMask is not None:\n",
+    "    mask = correctedMask\n",
     "croppedImage, croppedMask = imageoperations.cropToTumorMask(image, mask, bb)"
    ]
   },

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -323,7 +323,7 @@ class RadiomicsFeaturesExtractor:
       return featureVector
 
     # 2. Check whether loaded mask contains a valid ROI for feature extraction and get bounding box
-    (boundingBox,correctedMask) = imageoperations.checkMask(image, mask, **self.settings)
+    boundingBox, correctedMask = imageoperations.checkMask(image, mask, **self.settings)
 
     # Update the mask if it had to be resampled
     if correctedMask is not None:

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -323,7 +323,11 @@ class RadiomicsFeaturesExtractor:
       return featureVector
 
     # 2. Check whether loaded mask contains a valid ROI for feature extraction and get bounding box
-    boundingBox = imageoperations.checkMask(image, mask, **self.settings)
+    (boundingBox,correctedMask) = imageoperations.checkMask(image, mask, **self.settings)
+
+    # Update the mask if it had to be resampled
+    if correctedMask is not None:
+      mask = correctedMask
 
     if boundingBox is None:
       # Mask checks failed, do not extract features and return the empty featureVector

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -176,8 +176,8 @@ def checkMask(imageNode, maskNode, **kwargs):
 
   If a check fails, an error is logged and a (None,None) tuple is returned. No features will be extracted for this mask.
   If the mask passes all tests, this function returns the bounding box, which is used in the :py:func:`cropToTumorMask`
-  function. 
-  
+  function.
+
   The bounding box is calculated during (1.) and used for the subsequent checks. The bounding box is
   calculated by SimpleITK.LabelStatisticsImageFilter() and returned as a tuple of indices: (L_x, U_x, L_y, U_y, L_z,
   U_z), where 'L' and 'U' are lower and upper bound, respectively, and 'x', 'y' and 'z' the three image dimensions.

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -171,9 +171,14 @@ def checkMask(imageNode, maskNode, **kwargs):
   4. Optional. Check if there are at least N voxels in the ROI. N is defined in ``minimumROISize``, this test is skipped
      if ``minimumROISize = None``.
 
-  If a check fails, an error is logged and a None value is returned. No features will be extracted for this mask.
+  This function returns a tuple of two items. The first item (if not None) is the bounding box of the mask. The second
+  item is the mask that has been corrected by resampling to the input image geometry (if that resampling was successful).
+
+  If a check fails, an error is logged and a (None,None) tuple is returned. No features will be extracted for this mask.
   If the mask passes all tests, this function returns the bounding box, which is used in the :py:func:`cropToTumorMask`
-  function. The bounding box is calculated during (1.) and used for the subsequent checks. The bounding box is
+  function. 
+  
+  The bounding box is calculated during (1.) and used for the subsequent checks. The bounding box is
   calculated by SimpleITK.LabelStatisticsImageFilter() and returned as a tuple of indices: (L_x, U_x, L_y, U_y, L_z,
   U_z), where 'L' and 'U' are lower and upper bound, respectively, and 'x', 'y' and 'z' the three image dimensions.
 
@@ -203,6 +208,9 @@ def checkMask(imageNode, maskNode, **kwargs):
   """
   global logger
 
+  boundingBox = None
+  correctedMask = None
+
   label = kwargs.get('label', 1)
   minDims = kwargs.get('minimumROIDimensions', 1)
   minSize = kwargs.get('minimumROISize', None)
@@ -218,7 +226,7 @@ def checkMask(imageNode, maskNode, **kwargs):
     # this test here only if lsif does not fail on the first attempt.
     if label not in lsif.GetLabels():
       logger.error('Label (%g) not present in mask', label)
-      return None
+      return (boundingBox, correctedMask)
   except RuntimeError as e:
     # If correctMask = True, try to resample the mask to the image geometry, otherwise return None ("fail")
     if not kwargs.get('correctMask', False):
@@ -231,22 +239,22 @@ def checkMask(imageNode, maskNode, **kwargs):
                      'see Documentation:Usage:Customizing the Extraction:Settings:geometryTolerance for more '
                      'information')
         logger.debug('Additional information on error.', exc_info=True)
-      return None
+      return (boundingBox, correctedMask)
 
     logger.warning('Image/Mask geometry mismatch, attempting to correct Mask')
 
-    maskNode = _correctMask(imageNode, maskNode, label)
-    if maskNode is None:  # Resampling failed (ROI outside image physical space
+    correctedMask = _correctMask(imageNode, maskNode, label)
+    if correctedMask is None:  # Resampling failed (ROI outside image physical space
       logger.error('Image/Mask correction failed, ROI invalid (not found or outside of physical image bounds)')
-      return None
+      return (boundingBox, correctedMask)
 
     # Resampling succesful, try to calculate boundingbox
     try:
-      lsif.Execute(imageNode, maskNode)
+      lsif.Execute(imageNode, correctedMask)
     except RuntimeError:
       logger.error('Calculation of bounding box failed, for more information run with DEBUG logging and check log')
       logger.debug('Bounding box calculation with resampled mask failed', exc_info=True)
-      return None
+      return (boundingBox, correctedMask)
 
   # LBound and UBound of the bounding box, as (L_X, U_X, L_Y, U_Y, L_Z, U_Z)
   boundingBox = numpy.array(lsif.GetBoundingBox(label))
@@ -255,16 +263,16 @@ def checkMask(imageNode, maskNode, **kwargs):
   ndims = numpy.sum((boundingBox[1::2] - boundingBox[0::2] + 1) > 1)  # UBound - LBound + 1 = Size
   if ndims <= minDims:
     logger.error('mask has too few dimensions (number of dimensions %d, minimum required %d)', ndims, minDims)
-    return None
+    return (boundingBox, correctedMask)
 
   if minSize is not None:
     logger.debug('Checking minimum size requirements (minimum size: %d)', minSize)
     roiSize = lsif.GetCount(label)
     if roiSize <= minSize:
       logger.error('Size of the ROI is too small (minimum size: %g, ROI size: %g', minSize, roiSize)
-      return None
+      return (boundingBox, correctedMask)
 
-  return boundingBox
+  return (boundingBox, correctedMask)
 
 
 def _correctMask(imageNode, maskNode, label):

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -133,7 +133,9 @@ class RadiomicsTestUtils:
                                                                 interpolator,
                                                                 self._kwargs.get('label', 1),
                                                                 self._kwargs.get('padDistance', 5))
-      bb = imageoperations.checkMask(self._image, self._mask)
+      (bb,correctedMask) = imageoperations.checkMask(self._image, self._mask)
+      if correctedMask is not None:
+        self._mask = correctedMask
       self._image, self._mask = imageoperations.cropToTumorMask(self._image, self._mask, bb)
       self._testCase = testCase
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -133,7 +133,7 @@ class RadiomicsTestUtils:
                                                                 interpolator,
                                                                 self._kwargs.get('label', 1),
                                                                 self._kwargs.get('padDistance', 5))
-      (bb,correctedMask) = imageoperations.checkMask(self._image, self._mask)
+      bb, correctedMask = imageoperations.checkMask(self._image, self._mask)
       if correctedMask is not None:
         self._mask = correctedMask
       self._image, self._mask = imageoperations.cropToTumorMask(self._image, self._mask, bb)


### PR DESCRIPTION
This resolves #259

In the situation when the mask was corrected to compensate for the differences
between the image and mask geometry, the updated mask was not propagated to be
used for feature calculation.