### PR TITLE
Fix bug when creating symmetrical GLCM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ Release Notes
 Next Release
 ------------
 
+Bug fixes
+#########
+
+- In GLCM, the matrix is made symmetrical by adding the transposed matrix. However, ``numpy.transpose`` returns a view
+  and not a copy of the array, causing erroneous results when adding it to the original array. use
+  ``numpy.ndarray.copy`` to prevent this bug. **N.B. This affects the feature values calculated by GLCM when symmetrical
+  matrix is enabled (as is the default setting).**
+
 -----------------
 PyRadiomics 1.2.0
 -----------------

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -186,7 +186,9 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     # Optionally make GLCMs symmetrical for each angle
     if self.symmetricalGLCM:
       self.logger.debug('Create symmetrical matrix')
-      P_glcm += numpy.transpose(P_glcm, (1, 0, 2))
+      # Transpose and copy GLCM and add it to P_glcm. Numpy.transpose returns a view if possible, use .copy() to ensure
+      # a copy of the array is used and not just a view (otherwise erroneous additions can occur)
+      P_glcm += numpy.transpose(P_glcm, (1, 0, 2)).copy()
 
     # Optionally apply a weighting factor
     if self.weightingNorm is not None:


### PR DESCRIPTION
To make GLCM symmetrical, the python code performed an inplace addition: `P_glcm += numpy.transpose(P_glcm, (1, 0, 2))`. However, when the matrix exceeds a certain size, this produces buggy behaviour, where for some elements, the calculated value equals `P_glcm += P_glcm + numpy.transpose(P_glcm, (1, 0, 2))`. This is caused by the fact that numpy.transpose returns a *view*, and not a copy of the array. Then, if the additions have to be processed in multiple chunks, the addition will become erroneous.

Use `numpy.copy` to get a transposed copy of the GLCM and not just a view of the GLCM.