### PR TITLE
Add case-specific labels in batchprocessing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Release Notes
 Next Release
 ------------
 
+New Features
+############
+
+- Add a row by row customization of the extraction label in the batch processing command line script, as well as both
+  batchprocessing examples.
+
 Bug fixes
 #########
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -79,7 +79,10 @@ Command Line Use
   represents one combination of an image and a segmentation and contains at least 2 elements: 1) path/to/image,
   2) path/to/mask. The headers specify the column names and **must** be "Image" and "Mask" for image and mask location,
   respectively (capital sensitive). Additional columns may also be specified, all columns are copied to the output in
-  the same order (with calculated features appended after last column).
+  the same order (with calculated features appended after last column). To specify custom label values for each
+  combination, a column "Label" can optionally be added, which specifies the desired extraction label for each
+  combination. Values specified in this column take precedence over label values specified in the parameter file or on
+  the commandline. If a row contains no value, the default (or globally customized) value is used instead.
 
   .. note::
 

--- a/examples/batchProcessingWithPandas.py
+++ b/examples/batchProcessingWithPandas.py
@@ -82,6 +82,12 @@ def main():
 
     imageFilepath = flists[entry]['Image']
     maskFilepath = flists[entry]['Mask']
+    label = flists[entry].get('Label', None)
+
+    if str(label).isdigit():
+      label = int(label)
+    else:
+      label = None
 
     if (imageFilepath is not None) and (maskFilepath is not None):
       featureVector = flists[entry]  # This is a pandas Series
@@ -92,7 +98,7 @@ def main():
         # PyRadiomics returns the result as an ordered dictionary, which can be easily converted to a pandas Series
         # The keys in the dictionary will be used as the index (labels for the rows), with the values of the features
         # as the values in the rows.
-        result = pandas.Series(extractor.execute(imageFilepath, maskFilepath))
+        result = pandas.Series(extractor.execute(imageFilepath, maskFilepath, label))
         featureVector = featureVector.append(result)
       except Exception:
         logger.error('FEATURE EXTRACTION FAILED:', exc_info=True)

--- a/examples/batchprocessing.py
+++ b/examples/batchprocessing.py
@@ -76,6 +76,12 @@ def main():
 
     imageFilepath = entry['Image']
     maskFilepath = entry['Mask']
+    label = entry.get('Label', None)
+
+    if str(label).isdigit():
+      label = int(label)
+    else:
+      label = None
 
     if (imageFilepath is not None) and (maskFilepath is not None):
       featureVector = collections.OrderedDict(entry)
@@ -83,7 +89,7 @@ def main():
       featureVector['Mask'] = os.path.basename(maskFilepath)
 
       try:
-        featureVector.update(extractor.execute(imageFilepath, maskFilepath))
+        featureVector.update(extractor.execute(imageFilepath, maskFilepath, label))
 
         with open(outputFilepath, 'a') as outputFile:
           writer = csv.writer(outputFile, lineterminator='\n')

--- a/radiomics/scripts/commandlinebatch.py
+++ b/radiomics/scripts/commandlinebatch.py
@@ -107,7 +107,13 @@ def main():
         featureVector['Mask'] = os.path.basename(maskFilepath)
 
       try:
-        featureVector.update(extractor.execute(imageFilepath, maskFilepath, args.label))
+        entryLabel = entry.get('Label', None)
+        if str(entryLabel).isdigit():
+          label = int(entryLabel)
+        else:
+          label = args.label
+
+        featureVector.update(extractor.execute(imageFilepath, maskFilepath, label))
 
         if args.format == 'csv':
           writer = csv.writer(args.outFile, lineterminator='\n')


### PR DESCRIPTION
Add functionality to allow users to specify different labels for different combinations in the input file for batchprocessing.
This is achieved through an additonal (optional) column `Label`. Integer values in this column then take precedence over any other form
of label customization (e.g. specifying the label on the command line or in the parameter file).

cc @Radiomics/developers 