### PR TITLE
Replace SimpleITK's eigenvalue decomposition with a python one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Bug fixes
   and not a copy of the array, causing erroneous results when adding it to the original array. use
   ``numpy.ndarray.copy`` to prevent this bug. **N.B. This affects the feature values calculated by GLCM when symmetrical
   matrix is enabled (as is the default setting).**
+- Use a python implementation to compute eigenvalues for ``shape.py`` instead of SimpleITK. The implementation in
+  SimpleITK assumes segmented voxels to be consecutive on the x-axis lines. Furthermore, it also assumes that all voxels
+  on a given line of x have the same values for y and z (which is not necessarily the case).
+  (`#264 <https://github.com/Radiomics/pyradiomics/pull/264>`_)
 
 -----------------
 PyRadiomics 1.2.0


### PR DESCRIPTION
The eigenvalue decomposition calculation does not account for non-consecutive voxels in a line (along x dimension), causing the calculated values for the principal moments to be erroneous when a lesion has 'holes' in it. Furthermore, it assumes that all voxels on line x = i have identical y and z coordinates, but this is not necessarily the case.