### PR TITLE
Update license to 3-clause BSD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ New Features
 
 - Add a row by row customization of the extraction label in the batch processing command line script, as well as both
   batchprocessing examples.
+  (`#262 <https://github.com/Radiomics/pyradiomics/pull/262>`_)
 
 Bug fixes
 #########
@@ -19,6 +20,7 @@ Bug fixes
   and not a copy of the array, causing erroneous results when adding it to the original array. use
   ``numpy.ndarray.copy`` to prevent this bug. **N.B. This affects the feature values calculated by GLCM when symmetrical
   matrix is enabled (as is the default setting).**
+  (`#261 <https://github.com/Radiomics/pyradiomics/pull/261>`_)
 - Use a python implementation to compute eigenvalues for ``shape.py`` instead of SimpleITK. The implementation in
   SimpleITK assumes segmented voxels to be consecutive on the x-axis lines. Furthermore, it also assumes that all voxels
   on a given line of x have the same values for y and z (which is not necessarily the case).
@@ -38,7 +40,8 @@ Documentation
 
 - Update reference. (`#271 <https://github.com/Radiomics/pyradiomics/pull/271>`_)
 - Move section "Customizing the Extraction" to the top level, to make it more visible.
-  (`#265 <https://github.com/Radiomics/pyradiomics/pull/271>`_)
+  (`#271 <https://github.com/Radiomics/pyradiomics/pull/271>`_)
+- Change License to 3-clause BSD (`#272 <https://github.com/Radiomics/pyradiomics/pull/272>`_
 
 Internal API
 ############

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,199 +1,21 @@
+Copyright 2017 Harvard Medical School
 
-For more information, please see:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
 
-                      http://www.slicer.org
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
 
-The 3D Slicer license below is a BSD style license, with extensions
-to cover contributions and other issues specific to 3D Slicer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
 
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
 
-3D Slicer Contribution and Software License Agreement ("Agreement")
-Version 1.0 (December 20, 2005)
-
-This Agreement covers contributions to and downloads from the 3D
-Slicer project ("Slicer") maintained by The Brigham and Women's
-Hospital, Inc. ("Brigham"). Part A of this Agreement applies to
-contributions of software and/or data to Slicer (including making
-revisions of or additions to code and/or data already in Slicer). Part
-B of this Agreement applies to downloads of software and/or data from
-Slicer. Part C of this Agreement applies to all transactions with
-Slicer. If you distribute Software (as defined below) downloaded from
-Slicer, all of the paragraphs of Part B of this Agreement must be
-included with and apply to such Software.
-
-Your contribution of software and/or data to Slicer (including prior
-to the date of the first publication of this Agreement, each a
-"Contribution") and/or downloading, copying, modifying, displaying,
-distributing or use of any software and/or data from Slicer
-(collectively, the "Software") constitutes acceptance of all of the
-terms and conditions of this Agreement. If you do not agree to such
-terms and conditions, you have no right to contribute your
-Contribution, or to download, copy, modify, display, distribute or use
-the Software.
-
-PART A. CONTRIBUTION AGREEMENT - License to Brigham with Right to
-Sublicense ("Contribution Agreement").
-
-1. As used in this Contribution Agreement, "you" means the individual
-   contributing the Contribution to Slicer and the institution or
-   entity which employs or is otherwise affiliated with such
-   individual in connection with such Contribution.
-
-2. This Contribution Agreement applies to all Contributions made to
-   Slicer, including without limitation Contributions made prior to
-   the date of first publication of this Agreement. If at any time you
-   make a Contribution to Slicer, you represent that (i) you are
-   legally authorized and entitled to make such Contribution and to
-   grant all licenses granted in this Contribution Agreement with
-   respect to such Contribution; (ii) if your Contribution includes
-   any patient data, all such data is de-identified in accordance with
-   U.S. confidentiality and security laws and requirements, including
-   but not limited to the Health Insurance Portability and
-   Accountability Act (HIPAA) and its regulations, and your disclosure
-   of such data for the purposes contemplated by this Agreement is
-   properly authorized and in compliance with all applicable laws and
-   regulations; and (iii) you have preserved in the Contribution all
-   applicable attributions, copyright notices and licenses for any
-   third party software or data included in the Contribution.
-
-3. Except for the licenses granted in this Agreement, you reserve all
-   right, title and interest in your Contribution.
-
-4. You hereby grant to Brigham, with the right to sublicense, a
-   perpetual, worldwide, non-exclusive, no charge, royalty-free,
-   irrevocable license to use, reproduce, make derivative works of,
-   display and distribute the Contribution. If your Contribution is
-   protected by patent, you hereby grant to Brigham, with the right to
-   sublicense, a perpetual, worldwide, non-exclusive, no-charge,
-   royalty-free, irrevocable license under your interest in patent
-   rights covering the Contribution, to make, have made, use, sell and
-   otherwise transfer your Contribution, alone or in combination with
-   any other code.
-
-5. You acknowledge and agree that Brigham may incorporate your
-   Contribution into Slicer and may make Slicer available to members
-   of the public on an open source basis under terms substantially in
-   accordance with the Software License set forth in Part B of this
-   Agreement. You further acknowledge and agree that Brigham shall
-   have no liability arising in connection with claims resulting from
-   your breach of any of the terms of this Agreement.
-
-6. YOU WARRANT THAT TO THE BEST OF YOUR KNOWLEDGE YOUR CONTRIBUTION
-   DOES NOT CONTAIN ANY CODE THAT REQURES OR PRESCRIBES AN "OPEN
-   SOURCE LICENSE" FOR DERIVATIVE WORKS (by way of non-limiting
-   example, the GNU General Public License or other so-called
-   "reciprocal" license that requires any derived work to be licensed
-   under the GNU General Public License or other "open source
-   license").
-
-PART B. DOWNLOADING AGREEMENT - License from Brigham with Right to
-Sublicense ("Software License").
-
-1. As used in this Software License, "you" means the individual
-   downloading and/or using, reproducing, modifying, displaying and/or
-   distributing the Software and the institution or entity which
-   employs or is otherwise affiliated with such individual in
-   connection therewith. The Brigham and Women?s Hospital,
-   Inc. ("Brigham") hereby grants you, with right to sublicense, with
-   respect to Brigham's rights in the software, and data, if any,
-   which is the subject of this Software License (collectively, the
-   "Software"), a royalty-free, non-exclusive license to use,
-   reproduce, make derivative works of, display and distribute the
-   Software, provided that:
-
-(a) you accept and adhere to all of the terms and conditions of this
-Software License;
-
-(b) in connection with any copy of or sublicense of all or any portion
-of the Software, all of the terms and conditions in this Software
-License shall appear in and shall apply to such copy and such
-sublicense, including without limitation all source and executable
-forms and on any user documentation, prefaced with the following
-words: "All or portions of this licensed product (such portions are
-the "Software") have been obtained under license from The Brigham and
-Women's Hospital, Inc. and are subject to the following terms and
-conditions:"
-
-(c) you preserve and maintain all applicable attributions, copyright
-notices and licenses included in or applicable to the Software;
-
-(d) modified versions of the Software must be clearly identified and
-marked as such, and must not be misrepresented as being the original
-Software; and
-
-(e) you consider making, but are under no obligation to make, the
-source code of any of your modifications to the Software freely
-available to others on an open source basis.
-
-2. The license granted in this Software License includes without
-   limitation the right to (i) incorporate the Software into
-   proprietary programs (subject to any restrictions applicable to
-   such programs), (ii) add your own copyright statement to your
-   modifications of the Software, and (iii) provide additional or
-   different license terms and conditions in your sublicenses of
-   modifications of the Software; provided that in each case your use,
-   reproduction or distribution of such modifications otherwise
-   complies with the conditions stated in this Software License.
-
-3. This Software License does not grant any rights with respect to
-   third party software, except those rights that Brigham has been
-   authorized by a third party to grant to you, and accordingly you
-   are solely responsible for (i) obtaining any permissions from third
-   parties that you need to use, reproduce, make derivative works of,
-   display and distribute the Software, and (ii) informing your
-   sublicensees, including without limitation your end-users, of their
-   obligations to secure any such required permissions.
-
-4. The Software has been designed for research purposes only and has
-   not been reviewed or approved by the Food and Drug Administration
-   or by any other agency. YOU ACKNOWLEDGE AND AGREE THAT CLINICAL
-   APPLICATIONS ARE NEITHER RECOMMENDED NOR ADVISED. Any
-   commercialization of the Software is at the sole risk of the party
-   or parties engaged in such commercialization. You further agree to
-   use, reproduce, make derivative works of, display and distribute
-   the Software in compliance with all applicable governmental laws,
-   regulations and orders, including without limitation those relating
-   to export and import control.
-
-5. The Software is provided "AS IS" and neither Brigham nor any
-   contributor to the software (each a "Contributor") shall have any
-   obligation to provide maintenance, support, updates, enhancements
-   or modifications thereto. BRIGHAM AND ALL CONTRIBUTORS SPECIFICALLY
-   DISCLAIM ALL EXPRESS AND IMPLIED WARRANTIES OF ANY KIND INCLUDING,
-   BUT NOT LIMITED TO, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR
-   A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
-   BRIGHAM OR ANY CONTRIBUTOR BE LIABLE TO ANY PARTY FOR DIRECT,
-   INDIRECT, SPECIAL, INCIDENTAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES
-   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY ARISING IN ANY WAY
-   RELATED TO THE SOFTWARE, EVEN IF BRIGHAM OR ANY CONTRIBUTOR HAS
-   BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. TO THE MAXIMUM
-   EXTENT NOT PROHIBITED BY LAW OR REGULATION, YOU FURTHER ASSUME ALL
-   LIABILITY FOR YOUR USE, REPRODUCTION, MAKING OF DERIVATIVE WORKS,
-   DISPLAY, LICENSE OR DISTRIBUTION OF THE SOFTWARE AND AGREE TO
-   INDEMNIFY AND HOLD HARMLESS BRIGHAM AND ALL CONTRIBUTORS FROM AND
-   AGAINST ANY AND ALL CLAIMS, SUITS, ACTIONS, DEMANDS AND JUDGMENTS
-   ARISING THEREFROM.
-
-6. None of the names, logos or trademarks of Brigham or any of
-   Brigham's affiliates or any of the Contributors, or any funding
-   agency, may be used to endorse or promote products produced in
-   whole or in part by operation of the Software or derived from or
-   based on the Software without specific prior written permission
-   from the applicable party.
-
-7. Any use, reproduction or distribution of the Software which is not
-   in accordance with this Software License shall automatically revoke
-   all rights granted to you under this Software License and render
-   Paragraphs 1 and 2 of this Software License null and void.
-
-8. This Software License does not grant any rights in or to any
-   intellectual property owned by Brigham or any Contributor except
-   those rights expressly granted hereunder.
-
-PART C. MISCELLANEOUS
-
-This Agreement shall be governed by and construed in accordance with
-the laws of The Commonwealth of Massachusetts without regard to
-principles of conflicts of law. This Agreement shall supercede and
-replace any license terms that you may have agreed to previously with
-respect to Slicer. 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See also the [requirements file](requirements.txt).
  - Implementation of this package as an [extension](https://github.com/Radiomics/SlicerRadiomics) to [3D Slicer](slicer.org)
 
 ### License
-This package is covered by the open source [3D Slicer License](LICENSE.txt).
+This package is covered by the open source [3-clause BSD License](LICENSE.txt).
 
 ### Developers
  - [Joost van Griethuysen](https://github.com/JoostJM)<sup>1,3,4</sup>

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ With this package we aim to establish a reference standard for Radiomic Analysis
 open-source platform for easy and reproducible Radiomic Feature extraction. By doing so, we hope to increase awareness
 of radiomic capabilities and expand the community.
 
-The platform supports both the feature extraction in 2D and 3D.
+The platform supports both the feature extraction in 2D and 3D. **Not intended for clinical use.**
 
-**If you publish any work which uses this package, please cite the following publication:**\
+**If you publish any work which uses this package, please cite the following publication:**
 *Joost JM van Griethuysen, Andriy Fedorov, Chintan Parmar, Ahmed Hosny, Nicole Aucoin, Vivek Narayan, Regina GH 
 Beets-Tan, Jean-Christophe Fillion-Robin, Steve Pieper, Hugo JWL Aerts, “Computational Radiomics System to Decode the
 Radiographic Phenotype”; Accepted Cancer Research 2017*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,7 @@ Pyradiomics Indices and Tables
 License
 -------
 
-This package is covered by the open source `3D Slicer License <https://github.com/Radiomics/pyradiomics/blob/master/LICENSE.txt>`_.
+This package is covered by the open source `3-clause BSD License <https://github.com/Radiomics/pyradiomics/blob/master/LICENSE.txt>`_.
 
 Developers
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,10 @@ Radiographic Phenotype”; Accepted Cancer Research 2017*
    This work was supported in part by the US National Cancer Institute grant
    5U24CA194354, QUANTITATIVE RADIOMICS SYSTEM DECODING THE TUMOR PHENOTYPE.
 
+.. warning::
+
+   Not intended for clinical use.
+
 Table of Contents
 -----------------
 


### PR DESCRIPTION
Addresses #268
Change the license to 3-clause BSD

Question: should there be a explicit statement "Not intended for clinical use" and if so, where should it go?
Possibilities:
 - Extra clause in the license
 - Statement at the top of the documentation
 - Statement at the top of ReadMe.md
 - Disclaimer in the log. (as a warning, and as such, will also be part of the output to the command window in default mode).

cc @Radiomics/developers 