### PR TITLE
Revise style in base initialization

### DIFF
--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -249,10 +249,10 @@ class _DummyProgressReporter(object):
     pass  # Nothing needs to be closed or handled, so just specify 'pass'
 
 
-def _getProgressReporter(*args, **kwargs):
+def getProgressReporter(*args, **kwargs):
   """
-  This function returns an instance of the progressReporter, or, if it is not set (None), returns a dummy progress
-  reporter.
+  This function returns an instance of the progressReporter, if it is set and the logging level is defined at level INFO
+  or DEBUG. In all other cases a dummy progress reporter is returned.
 
   To enable progress reporting, the progressReporter variable should be set to a class object (NOT an instance), which
   fits the following signature:
@@ -267,11 +267,11 @@ def _getProgressReporter(*args, **kwargs):
   `__next__` function of the iterable (i.e. `return self.iterable.__next__()`). Any prints/progress reporting calls can
   then be inserted in this function prior to the return statement.
   """
-  global progressReporter
-  if progressReporter is None:
-    return _DummyProgressReporter(*args, **kwargs)
-  else:
+  global handler, progressReporter
+  if progressReporter is not None and logging.NOTSET < handler.level <= logging.INFO:
     return progressReporter(*args, **kwargs)
+  else:
+    return _DummyProgressReporter(*args, **kwargs)
 
 progressReporter = None
 

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -61,12 +61,12 @@ class RadiomicsFeaturesBase(object):
       self.logger.warning('Missing input image or mask')
       return
 
-  def _initLesionWiseCalculation(self):
+  def _initSegmentBasedCalculation(self):
     self.imageArray = sitk.GetArrayFromImage(self.inputImage)
     self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label)  # boolean array
 
-    self.ROICoordinates = numpy.where(self.maskArray != 0)
-    self.size = numpy.max(self.ROICoordinates, 1) - numpy.min(self.ROICoordinates, 1) + 1
+    self.labelledVoxelCoordinates = numpy.where(self.maskArray != 0)
+    self.boundingBoxSize = numpy.max(self.labelledVoxelCoordinates, 1) - numpy.min(self.labelledVoxelCoordinates, 1) + 1
 
   def _applyBinning(self):
       self.matrix, self.binEdges = imageoperations.binImage(self.binWidth,

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -6,7 +6,7 @@ import numpy
 import SimpleITK as sitk
 import six
 
-import radiomics
+from radiomics import getProgressReporter, imageoperations
 
 class RadiomicsFeaturesBase(object):
   """
@@ -41,15 +41,13 @@ class RadiomicsFeaturesBase(object):
   def __init__(self, inputImage, inputMask, **kwargs):
     self.logger = logging.getLogger(self.__module__)
     self.logger.debug('Initializing feature class')
-    # check if the handler to stderr is set and its level is INFO or lower
-    if logging.NOTSET < radiomics.handler.level <= logging.INFO:
-      self.progressReporter = radiomics._getProgressReporter
-    else:
-      self.progressReporter = radiomics._DummyProgressReporter
+    self.progressReporter = getProgressReporter
 
     self.kwargs = kwargs
     self.binWidth = kwargs.get('binWidth', 25)
     self.label = kwargs.get('label', 1)
+
+    self.coefficients = {}
 
     # all features are disabled by default
     self.disableAllFeatures()
@@ -63,13 +61,19 @@ class RadiomicsFeaturesBase(object):
       self.logger.warning('Missing input image or mask')
       return
 
+  def _initLesionWiseCalculation(self):
     self.imageArray = sitk.GetArrayFromImage(self.inputImage)
-    self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label).astype('int')
+    self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label)  # boolean array
 
-    self.matrix = self.imageArray.astype('float')
-    self.matrixCoordinates = numpy.where(self.maskArray != 0)
+    self.ROICoordinates = numpy.where(self.maskArray != 0)
+    self.size = numpy.max(self.ROICoordinates, 1) - numpy.min(self.ROICoordinates, 1) + 1
 
-    self.targetVoxelArray = self.matrix[self.matrixCoordinates]
+  def _applyBinning(self):
+      self.matrix, self.binEdges = imageoperations.binImage(self.binWidth,
+                                                            self.imageArray,
+                                                            self.maskArray)
+      self.coefficients['grayLevels'] = numpy.unique(self.matrix[self.maskArray])
+      self.coefficients['Ng'] = int(numpy.max(self.coefficients['grayLevels']))  # max gray level in the ROI
 
   def enableFeatureByName(self, featureName, enable=True):
     """

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -122,7 +122,7 @@ class RadiomicsFeaturesExtractor:
     If supplied file does not match the requirements (i.e. unrecognized names or invalid values for a setting), a
     pykwalify error is raised.
     """
-    dataDir = os.path.abspath(os.path.join(radiomics.__path__[0], 'schemas'))
+    dataDir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'schemas'))
     schemaFile = os.path.join(dataDir, 'paramSchema.yaml')
     schemaFuncs = os.path.join(dataDir, 'schemaFuncs.py')
     c = pykwalify.core.Core(source_file=paramsFile, schema_files=[schemaFile], extensions=[schemaFuncs])

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -30,13 +30,13 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     self.pixelSpacing = inputImage.GetSpacing()
     self.voxelArrayShift = kwargs.get('voxelArrayShift', 0)
 
-    self._initLesionWiseCalculation()
+    self._initSegmentBasedCalculation()
 
-  def _initLesionWiseCalculation(self):
-    super(RadiomicsFirstOrder, self)._initLesionWiseCalculation()
-    self.targetVoxelArray = self.imageArray[self.ROICoordinates].astype('float')
+  def _initSegmentBasedCalculation(self):
+    super(RadiomicsFirstOrder, self)._initSegmentBasedCalculation()
+    self.targetVoxelArray = self.imageArray[self.labelledVoxelCoordinates].astype('float')
 
-    self.logger.debug('Feature class initialized')
+    self.logger.debug('First order feature class initialized')
 
   def _moment(self, a, moment=1, axis=0):
     r"""

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -30,6 +30,12 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     self.pixelSpacing = inputImage.GetSpacing()
     self.voxelArrayShift = kwargs.get('voxelArrayShift', 0)
 
+    self._initLesionWiseCalculation()
+
+  def _initLesionWiseCalculation(self):
+    super(RadiomicsFirstOrder, self)._initLesionWiseCalculation()
+    self.targetVoxelArray = self.imageArray[self.ROICoordinates].astype('float')
+
     self.logger.debug('Feature class initialized')
 
   def _moment(self, a, moment=1, axis=0):

--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -104,10 +104,10 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
 
     self.P_glcm = None
 
-    self._initLesionWiseCalculation()
+    self._initSegmentBasedCalculation()
 
-  def _initLesionWiseCalculation(self):
-    super(RadiomicsGLCM, self)._initLesionWiseCalculation()
+  def _initSegmentBasedCalculation(self):
+    super(RadiomicsGLCM, self)._initSegmentBasedCalculation()
 
     self._applyBinning()
 
@@ -118,7 +118,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
 
     self._calculateCoefficients()
 
-    self.logger.debug('Feature class initialized, calculated GLCM with shape %s', self.P_glcm.shape)
+    self.logger.debug('GLCM feature class initialized, calculated GLCM with shape %s', self.P_glcm.shape)
 
   def _calculateMatrix(self):
     r"""
@@ -132,7 +132,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     # Exclude voxels outside segmentation, due to binning, no negative values will be encountered inside the mask
     self.matrix[self.maskArray == 0] = -1
 
-    angles = imageoperations.generateAngles(self.size, **self.kwargs)
+    angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
 
     grayLevels = self.coefficients['grayLevels']
 
@@ -168,7 +168,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def _calculateCMatrix(self):
     self.logger.debug('Calculating GLCM matrix in C')
 
-    angles = imageoperations.generateAngles(self.size, **self.kwargs)
+    angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
     Ng = self.coefficients['Ng']
 
     P_glcm = cMatrices.calculate_glcm(self.matrix, self.maskArray, angles, Ng)

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -78,15 +78,17 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     self.weightingNorm = kwargs.get('weightingNorm', None)  # manhattan, euclidean, infinity
 
-    self.coefficients = {}
-    self.P_glrlm = {}
+    self.P_glrlm = None
+
+    self._initLesionWiseCalculation()
+
+  def _initLesionWiseCalculation(self):
+    super(RadiomicsGLRLM, self)._initLesionWiseCalculation()
+    self._applyBinning()
 
     # binning
-    self.matrix, self.binEdges = imageoperations.binImage(self.binWidth, self.matrix, self.matrixCoordinates)
-    self.coefficients['Ng'] = int(numpy.max(self.matrix[self.matrixCoordinates]))  # max gray level in the ROI
     self.coefficients['Nr'] = numpy.max(self.matrix.shape)
-    self.coefficients['Np'] = self.targetVoxelArray.size
-    self.coefficients['grayLevels'] = numpy.unique(self.matrix[self.matrixCoordinates])
+    self.coefficients['Np'] = len(self.ROICoordinates[0])
 
     if cMatsEnabled():
       self.P_glrlm = self._calculateCMatrix()
@@ -108,9 +110,8 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     matrixDiagonals = []
 
-    size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(size,
+    angles = imageoperations.generateAngles(self.size,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
 
@@ -170,9 +171,8 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Ng = self.coefficients['Ng']
     Nr = self.coefficients['Nr']
 
-    size = numpy.max(self.matrixCoordinates, 1) - numpy.min(self.matrixCoordinates, 1) + 1
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(size,
+    angles = imageoperations.generateAngles(self.size,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
 

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -80,15 +80,15 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     self.P_glrlm = None
 
-    self._initLesionWiseCalculation()
+    self._initSegmentBasedCalculation()
 
-  def _initLesionWiseCalculation(self):
-    super(RadiomicsGLRLM, self)._initLesionWiseCalculation()
+  def _initSegmentBasedCalculation(self):
+    super(RadiomicsGLRLM, self)._initSegmentBasedCalculation()
     self._applyBinning()
 
     # binning
     self.coefficients['Nr'] = numpy.max(self.matrix.shape)
-    self.coefficients['Np'] = len(self.ROICoordinates[0])
+    self.coefficients['Np'] = len(self.labelledVoxelCoordinates[0])
 
     if cMatsEnabled():
       self.P_glrlm = self._calculateCMatrix()
@@ -97,7 +97,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     self._calculateCoefficients()
 
-    self.logger.debug('Feature class initialized, calculated GLRLM with shape %s', self.P_glrlm.shape)
+    self.logger.debug('GLRLM feature class initialized, calculated GLRLM with shape %s', self.P_glrlm.shape)
 
   def _calculateMatrix(self):
     self.logger.debug('Calculating GLRLM matrix in Python')
@@ -111,7 +111,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     matrixDiagonals = []
 
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.size,
+    angles = imageoperations.generateAngles(self.boundingBoxSize,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
 
@@ -172,7 +172,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.size,
+    angles = imageoperations.generateAngles(self.boundingBoxSize,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
 

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -36,7 +36,8 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
   Let:
 
   - :math:`\textbf{P}(i,j)` be the size zone matrix
-  - :math:`p(i,j)` be the normalized size zone matrix, defined as :math:`p(i,j) = \frac{\textbf{P}(i,j)}{\sum{\textbf{P}(i,j)}}`
+  - :math:`p(i,j)` be the normalized size zone matrix, defined as
+    :math:`p(i,j) = \frac{\textbf{P}(i,j)}{\sum{\textbf{P}(i,j)}}`
   - :math:`N_g` be the number of discreet intensity values in the image
   - :math:`N_s` be the number of discreet zone sizes in the image
   - :math:`N_p` be the number of voxels in the image
@@ -59,14 +60,14 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
 
     self.P_glszm = None
 
-    self._initLesionWiseCalculation()
+    self._initSegmentBasedCalculation()
 
-  def _initLesionWiseCalculation(self):
-    super(RadiomicsGLSZM, self)._initLesionWiseCalculation()
+  def _initSegmentBasedCalculation(self):
+    super(RadiomicsGLSZM, self)._initSegmentBasedCalculation()
 
     self._applyBinning()
 
-    self.coefficients['Np'] = len(self.ROICoordinates[0])
+    self.coefficients['Np'] = len(self.labelledVoxelCoordinates[0])
 
     if cMatsEnabled():
       self.P_glszm = self._calculateCMatrix()
@@ -75,7 +76,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
 
     self._calculateCoefficients()
 
-    self.logger.debug('Feature class initialized, calculated GLSZM with shape %s', self.P_glszm.shape)
+    self.logger.debug('GLSZM feature class initialized, calculated GLSZM with shape %s', self.P_glszm.shape)
 
   def _calculateMatrix(self):
     """
@@ -88,7 +89,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
 
     Np = self.coefficients['Np']
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.size,
+    angles = imageoperations.generateAngles(self.boundingBoxSize,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
 
@@ -104,7 +105,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
       # Iterate over all gray levels in the image
       for i_idx, i in enumerate(bar):
         ind = zip(*numpy.where(self.matrix == i))
-        ind = list(set(ind).intersection(set(zip(*self.ROICoordinates))))
+        ind = list(set(ind).intersection(set(zip(*self.labelledVoxelCoordinates))))
 
         while ind:  # check if ind is not empty: unprocessed regions for current gray level
           # Pop first coordinate of an unprocessed zone, start new stack
@@ -145,7 +146,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     self.logger.debug('Calculating GLSZM matrix in C')
 
     # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.size,
+    angles = imageoperations.generateAngles(self.boundingBoxSize,
                                             force2Dextraction=self.kwargs.get('force2D', False),
                                             force2Ddimension=self.kwargs.get('force2Ddimension', 0))
     Ng = self.coefficients['Ng']

--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -20,9 +20,9 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
   def __init__(self, inputImage, inputMask, **kwargs):
     super(RadiomicsShape, self).__init__(inputImage, inputMask, **kwargs)
 
-    self._initLesionWiseCalculation()
+    self._initSegmentBasedCalculation()
 
-  def _initLesionWiseCalculation(self):
+  def _initSegmentBasedCalculation(self):
 
     self.pixelSpacing = numpy.array(self.inputImage.GetSpacing()[::-1])
 
@@ -44,14 +44,14 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     # Reassign self.maskArray using the now-padded self.inputMask and make it binary
     self.maskArray = (sitk.GetArrayFromImage(self.inputMask) == self.label).astype('int')
-    self.ROICoordinates = numpy.where(self.maskArray != 0)
+    self.labelledVoxelCoordinates = numpy.where(self.maskArray != 0)
 
     self.logger.debug('Pre-calculate Volume, Surface Area and Eigenvalues')
 
     # Volume, Surface Area and eigenvalues are pre-calculated
     # Compute volume
     z, x, y = self.pixelSpacing
-    Np = len(self.ROICoordinates[0])
+    Np = len(self.labelledVoxelCoordinates[0])
     self.Volume = Np * (z * x * y)
 
     # Compute Surface Area
@@ -61,7 +61,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
       self.SurfaceArea = self._calculateSurfaceArea()
 
     # Compute eigenvalues and -vectors
-    coordinates = numpy.array(self.ROICoordinates, dtype='int').transpose((1, 0))  # Transpose equivalent to zip(*a)
+    coordinates = numpy.array(self.labelledVoxelCoordinates, dtype='int').transpose((1, 0))  # Transpose equals zip(*a)
     physicalCoordinates = [self.inputMask.TransformIndexToPhysicalPoint((idx.tolist())[::-1]) for idx in coordinates]
     physicalCoordinates -= numpy.mean(physicalCoordinates, axis=0)  # Centered at 0
     physicalCoordinates /= numpy.sqrt(Np)
@@ -72,7 +72,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     self.diameters = None  # Do not precompute diameters
 
-    self.logger.debug('Feature class initialized')
+    self.logger.debug('Shape feature class initialized')
 
   def _calculateSurfaceArea(self):
     self.logger.debug('Calculating Surface Area in Python')
@@ -83,10 +83,10 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     # instantiate lookup tables
     edgeTable, triTable = self._getMarchingTables()
 
-    minBounds = numpy.array([numpy.min(self.ROICoordinates[0]), numpy.min(self.ROICoordinates[1]),
-                             numpy.min(self.ROICoordinates[2])])
-    maxBounds = numpy.array([numpy.max(self.ROICoordinates[0]), numpy.max(self.ROICoordinates[1]),
-                             numpy.max(self.ROICoordinates[2])])
+    minBounds = numpy.array([numpy.min(self.labelledVoxelCoordinates[0]), numpy.min(self.labelledVoxelCoordinates[1]),
+                             numpy.min(self.labelledVoxelCoordinates[2])])
+    maxBounds = numpy.array([numpy.max(self.labelledVoxelCoordinates[0]), numpy.max(self.labelledVoxelCoordinates[1]),
+                             numpy.max(self.labelledVoxelCoordinates[2])])
     minBounds = numpy.where(minBounds < 1, 1, minBounds)
     maxBounds = numpy.where(maxBounds > self.maskArray.shape, self.maskArray.shape, maxBounds)
 
@@ -162,9 +162,9 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
     3. Maximum 3D diameter
     """
     self.logger.debug('Calculating Maximum 3D diameter in C')
-    Ns = len(self.ROICoordinates[0])
-    size = numpy.max(self.ROICoordinates, 1) - numpy.min(self.ROICoordinates, 1) + 1
-    angles = imageoperations.generateAngles(size)
+    Ns = len(self.labelledVoxelCoordinates[0])
+    boundingBoxSize = numpy.max(self.labelledVoxelCoordinates, 1) - numpy.min(self.labelledVoxelCoordinates, 1) + 1
+    angles = imageoperations.generateAngles(boundingBoxSize)
     return cShape.calculate_diameter(self.maskArray, self.pixelSpacing, angles, Ns)
 
   def getVolumeFeatureValue(self):


### PR DESCRIPTION
Groups together common functions and splits assigning passed variables (such as `inputImage` and `inputMask`) and feature class percalculation (such as calculating the texture matrix), which enables customized initialization, such as in  `shape.py`.

Additionally, renamed matrixCoordinates to ROICoordinates, and moved assignment of the progress reporter to `__init__.py` (therefore only needing 1 call to a global function from the `base.py` module)