### PR TITLE
Fix python3 incompatibility when getting a test case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,15 @@ RUN /bin/bash -c "source activate python2 \
     && python setup.py install"
 
 # Install sample data and notebooks
-ADD data/ /home/jovyan/work/example_data/
-ADD notebooks/RadiomicsExample.ipynb /home/jovyan/work/
-ADD notebooks/FeatureVisualization.ipynb /home/jovyan/work/
-ADD notebooks/FeatureVisualizationWithClustering.ipynb /home/jovyan/work/
-ADD notebooks/FilteringEffects.ipynb /home/jovyan/work/
-ADD examples/exampleSettings/Params.yaml /home/jovyan/work/
+ADD data/ /home/jovyan/work/data/
+ADD notebooks/RadiomicsExample.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/FeatureVisualization.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/FeatureVisualizationWithClustering.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/FilteringEffects.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/helloRadiomics.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/helloFeatureClass.ipynb /home/jovyan/work/notebooks/
+ADD notebooks/PyRadiomicsExample.ipynb /home/jovyan/work/notebooks/
+ADD examples/exampleSettings/Params.yaml /home/jovyan/work/examples/exampleSettings/
 
 # Make a global directory and link it to the work directory
 RUN mkdir /data
@@ -42,11 +45,11 @@ RUN chown -R jovyan:users /home/jovyan/work
 
 # Trust the notebooks that we've installed
 USER jovyan
-RUN jupyter trust /home/jovyan/work/*.ipynb
+RUN jupyter trust /home/jovyan/work/notebooks/*.ipynb
 
 # Run the notebooks
-RUN jupyter nbconvert --ExecutePreprocessor.kernel_name=python2 --ExecutePreprocessor.timeout=-1 --to notebook --execute /home/jovyan/work/*.ipynb
-RUN jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.timeout=-1 --to notebook --execute /home/jovyan/work/*.ipynb
+RUN jupyter nbconvert --ExecutePreprocessor.kernel_name=python2 --ExecutePreprocessor.timeout=-1 --to notebook --execute /home/jovyan/work/notebooks/helloRadiomics.ipynb /home/jovyan/work/notebooks/helloFeatureClass.ipynb /home/jovyan/work/notebooks/PyRadiomicsExample.ipynb
+RUN jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.timeout=-1 --to notebook --execute /home/jovyan/work/notebooks/helloRadiomics.ipynb /home/jovyan/work/notebooks/helloFeatureClass.ipynb /home/jovyan/work/notebooks/PyRadiomicsExample.ipynb
 
 # The user's data will show up as /data
 VOLUME /data

--- a/notebooks/FeatureVisualization.ipynb
+++ b/notebooks/FeatureVisualization.ipynb
@@ -51,6 +51,8 @@
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
     "if not os.path.isfile(filename):\n",
+    "    if not os.path.isdir('example_data'):\n",
+    "        os.mkdir('example_data')\n",
     "    print (\"retrieving\")\n",
     "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",

--- a/notebooks/FeatureVisualization.ipynb
+++ b/notebooks/FeatureVisualization.ipynb
@@ -42,15 +42,17 @@
    ],
    "source": [
     "# Download the zip file if it does not exist\n",
-    "import urllib, os, zipfile\n",
+    "import os, zipfile\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
+    "\n",
+    "from six.moves import urllib\n",
     "\n",
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
     "if not os.path.isfile(filename):\n",
     "    print (\"retrieving\")\n",
-    "    urllib.urlretrieve(url, filename)\n",
+    "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",
     "    print (\"file already downloaded\")\n",
     "    \n",
@@ -59,7 +61,7 @@
     "    print (\"unzipping\")\n",
     "    z = zipfile.ZipFile(filename)\n",
     "    z.extractall('example_data')\n",
-    "    print (\"done unzipping\")\n"
+    "    print (\"done unzipping\")"
    ]
   },
   {
@@ -74,7 +76,7 @@
    "source": [
     "# Import some libraries\n",
     "import SimpleITK as sitk\n",
-    "import radiomics\n"
+    "import radiomics"
    ]
   },
   {
@@ -117,7 +119,7 @@
     "    \n",
     "\n",
     "# A list of the valid features, sorted\n",
-    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))\n"
+    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))"
    ]
   },
   {
@@ -168,7 +170,6 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "from sklearn import manifold\n",
     "from sklearn.metrics import euclidean_distances\n",
     "from sklearn.decomposition import PCA\n",
@@ -181,7 +182,7 @@
     "mds = manifold.MDS(n_components=2, max_iter=5000, eps=1e-12, random_state=seed,\n",
     "                   n_init=10,\n",
     "                   dissimilarity=\"precomputed\", n_jobs=1, metric=False)\n",
-    "pos = mds.fit_transform(similarities)\n"
+    "pos = mds.fit_transform(similarities)"
    ]
   },
   {
@@ -311,7 +312,7 @@
     "f, ax = plt.subplots(figsize=(15, 10))\n",
     "\n",
     "# Draw the heatmap using seaborn\n",
-    "sns.heatmap(corr, vmax=.8, square=True)\n"
+    "sns.heatmap(corr, vmax=.8, square=True)"
    ]
   },
   {
@@ -372,7 +373,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -383,5 +384,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/FeatureVisualizationWithClustering.ipynb
+++ b/notebooks/FeatureVisualizationWithClustering.ipynb
@@ -53,6 +53,8 @@
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
     "if not os.path.isfile(filename):\n",
+    "    if not os.path.isdir('example_data'):\n",
+    "        os.mkdir('example_data')\n",
     "    print (\"retrieving\")\n",
     "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",

--- a/notebooks/FeatureVisualizationWithClustering.ipynb
+++ b/notebooks/FeatureVisualizationWithClustering.ipynb
@@ -44,15 +44,17 @@
    ],
    "source": [
     "# Download the zip file if it does not exist\n",
-    "import urllib, os, zipfile\n",
+    "import os, zipfile\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
+    "\n",
+    "from six.moves import urllib\n",
     "\n",
     "url = \"http://www.spl.harvard.edu/publications/bitstream/download/5270\"\n",
     "filename = 'example_data/Tumorbase.zip'\n",
     "if not os.path.isfile(filename):\n",
     "    print (\"retrieving\")\n",
-    "    urllib.urlretrieve(url, filename)\n",
+    "    urllib.request.urlretrieve(url, filename)\n",
     "else:\n",
     "    print (\"file already downloaded\")\n",
     "    \n",
@@ -61,7 +63,7 @@
     "    print (\"unzipping\")\n",
     "    z = zipfile.ZipFile(filename)\n",
     "    z.extractall('example_data')\n",
-    "    print (\"done unzipping\")\n"
+    "    print (\"done unzipping\")"
    ]
   },
   {
@@ -76,7 +78,7 @@
    "source": [
     "# Import some libraries\n",
     "import SimpleITK as sitk\n",
-    "import radiomics\n"
+    "import radiomics"
    ]
   },
   {
@@ -119,7 +121,7 @@
     "    \n",
     "\n",
     "# A list of the valid features, sorted\n",
-    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))\n"
+    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), features[1] )))"
    ]
   },
   {
@@ -170,7 +172,6 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "from sklearn import manifold\n",
     "from sklearn.metrics import euclidean_distances\n",
     "from sklearn.decomposition import PCA\n",
@@ -183,7 +184,7 @@
     "mds = manifold.MDS(n_components=2, max_iter=5000, eps=1e-12, random_state=seed,\n",
     "                   n_init=10,\n",
     "                   dissimilarity=\"precomputed\", n_jobs=1, metric=False)\n",
-    "pos = mds.fit_transform(similarities)\n"
+    "pos = mds.fit_transform(similarities)"
    ]
   },
   {
@@ -317,7 +318,7 @@
     "f, ax = plt.subplots(figsize=(15, 10))\n",
     "\n",
     "# Draw the heatmap using seaborn\n",
-    "sns.heatmap(corr, vmax=.8, square=True)\n"
+    "sns.heatmap(corr, vmax=.8, square=True)"
    ]
   },
   {
@@ -350,7 +351,7 @@
     "\n",
     "from scipy.cluster.hierarchy import dendrogram, linkage\n",
     "\n",
-    "Z = linkage(m,'ward')\n"
+    "Z = linkage(m,'ward')"
    ]
   },
   {
@@ -664,7 +665,7 @@
     }
    ],
    "source": [
-    "d.head()\n"
+    "d.head()"
    ]
   },
   {
@@ -701,7 +702,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -712,5 +713,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -8,7 +8,8 @@ import os
 import pkgutil
 import sys
 import tempfile
-import urllib
+
+from six.moves import urllib
 
 import numpy  # noqa: F401
 
@@ -211,8 +212,8 @@ def getTestCase(testCase, repoDirectory=None):
   # Download the test case files (image and label)
   url = r'https://github.com/Radiomics/pyradiomics/raw/master/data/%s_%s.nrrd'
   try:
-    urllib.urlretrieve(url % (testCase, 'image'), imageFile)
-    urllib.urlretrieve(url % (testCase, 'label'), maskFile)
+    urllib.request.urlretrieve(url % (testCase, 'image'), imageFile)
+    urllib.request.urlretrieve(url % (testCase, 'label'), maskFile)
   except Exception:
     logger.error('Download failed!', exc_info=True)
     return None, None


### PR DESCRIPTION
In python 3, the function `urlretrieve` is moved. Prevent incompatibility by using implementation in `six.moves`.
Affects the function to get a test case and the feature visualization notebooks.

Fixes #278
cc @Radiomics/developers 