### PR TITLE
Fix missing python 2 environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,17 @@ jobs:
             apt-get update
             apt-get install -y openssh-client openssh-server
       - run:
+          # Jupyter datascience notebook does not support python 2 anymore, install it manually.
+          # See also https://github.com/jupyter/docker-stacks/issues/432
+          # Next, install python 2 kernel globally, so it can be found from the root
+          name: Install Python 2 Kernel
+          command: |
+            conda create -n python2 python=2 ipykernel
+            pip install kernda --no-cache
+            $CONDA_DIR/envs/python2/bin/python -m ipykernel install
+            kernda -o -y /usr/local/share/jupyter/kernels/python2/kernel.json
+            pip uninstall kernda -y
+      - run:
           name: Install pyradiomics in Python 2 and 3
           command: |
             source activate python2
@@ -44,6 +55,3 @@ jobs:
             jupyter nbconvert --ExecutePreprocessor.kernel_name=python2 --ExecutePreprocessor.timeout=-1 --to notebook --output-dir /tmp --execute notebooks/helloRadiomics.ipynb notebooks/helloFeatureClass.ipynb notebooks/PyRadiomicsExample.ipynb
 
             jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.timeout=-1 --to notebook --output-dir /tmp --execute  notebooks/helloRadiomics.ipynb notebooks/helloFeatureClass.ipynb notebooks/PyRadiomicsExample.ipynb
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,19 @@ LABEL org.label-schema.build-data=$BUILD_DATE \
 
 USER root
 ADD . /root/pyradiomics
+
+# Jupyter datascience notebook does not support python 2 anymore, install it manually.
+# "source activate python2 || (...)" first checks if the python 2 environment exists,
+# and only installs if the environment does not exist
+# See also https://github.com/jupyter/docker-stacks/issues/432
+# Next, also install python 2 kernel globally, so it can be found from the root
+RUN /bin/bash -c "source activate python2 \
+    || (conda create -n python2 python=2 ipykernel \
+    && pip install kernda --no-cache \
+    && $CONDA_DIR/envs/python2/bin/python -m ipykernel install \
+    && kernda -o -y /usr/local/share/jupyter/kernels/python2/kernel.json \
+    && pip uninstall kernda -y)"
+
 # Install in Python 3
 RUN /bin/bash -c "source activate root \
     && cd /root/pyradiomics \

--- a/notebooks/FeatureVisualization.ipynb
+++ b/notebooks/FeatureVisualization.ipynb
@@ -78,7 +78,7 @@
    "source": [
     "# Import some libraries\n",
     "import SimpleITK as sitk\n",
-    "import radiomics"
+    "from radiomics import featureextractor"
    ]
   },
   {

--- a/notebooks/FeatureVisualizationWithClustering.ipynb
+++ b/notebooks/FeatureVisualizationWithClustering.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "# Import some libraries\n",
     "import SimpleITK as sitk\n",
-    "import radiomics"
+    "from radiomics import featureextractor"
    ]
   },
   {

--- a/notebooks/FilteringEffects.ipynb
+++ b/notebooks/FilteringEffects.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "# Radiomics package\n",
-    "import radiomics\n",
+    "from radiomics import featureextractor\n",
     "\n",
     "import six, numpy as np"
    ]
@@ -61,7 +61,7 @@
     "import SimpleITK as sitk\n",
     "\n",
     "image = sitk.ReadImage(\"example_data/brain1_image.nrrd\")\n",
-    "label = sitk.ReadImage(\"example_data/brain1_label.nrrd\")\n"
+    "label = sitk.ReadImage(\"example_data/brain1_label.nrrd\")"
    ]
   },
   {
@@ -135,11 +135,11 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
     "# Instantiate the extractor\n",
     "params = os.path.join(os.getcwd(), '..', 'examples', 'exampleSettings', 'Params.yaml')\n",
     "\n",
-    "extractor = featureextractor.RadiomicsFeaturesExtractor(params)",
-    "\n",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor(params)\n",
     "# Construct a set of SimpleITK filter objects\n",
     "filters = {\n",
     "    \"AdditiveGaussianNoise\" : sitk.AdditiveGaussianNoiseImageFilter(),\n",
@@ -214,7 +214,7 @@
     "for key, value in six.iteritems(filters):\n",
     "    print ( \"filtering with \" + key )\n",
     "    filtered_image = value.Execute(image)\n",
-    "    results[key] = extractor.execute(filtered_image, label)\n"
+    "    results[key] = extractor.execute(filtered_image, label)"
    ]
   },
   {
@@ -239,7 +239,7 @@
    "source": [
     "# Keep an index of filters and features\n",
     "filter_index = list(sorted(filters.keys()))\n",
-    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), results[filter_index[0]] )))\n"
+    "feature_names = list(sorted(filter ( lambda k: k.startswith(\"original_\"), results[filter_index[0]] )))"
    ]
   },
   {
@@ -321,7 +321,7 @@
     "print (\"\\n\")\n",
     "print (\"Bottom 10 features with _smallest_ coefficient of variation\")\n",
     "for i in range(-11,-1):\n",
-    "    print (\"Feature: {:<50} CV: {}\".format ( cv_sorted[i], cv[cv_sorted[i]]))\n"
+    "    print (\"Feature: {:<50} CV: {}\".format ( cv_sorted[i], cv[cv_sorted[i]]))"
    ]
   }
  ],
@@ -334,7 +334,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/notebooks/RadiomicsExample.ipynb
+++ b/notebooks/RadiomicsExample.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "# Radiomics package\n",
-    "import radiomics\n",
+    "from radiomics import featureextractor\n",
     "\n",
     "import six, numpy as np"
    ]
@@ -166,10 +166,11 @@
     }
    ],
    "source": [
+    "import os\n",
     "# Instantiate the extractor\n",
     "params = os.path.join(os.getcwd(), '..', 'examples', 'exampleSettings', 'Params.yaml')\n",
     "\n",
-    "extractor = featureextractor.RadiomicsFeaturesExtractor(params)",
+    "extractor = featureextractor.RadiomicsFeaturesExtractor(params)\n",
     "result_1 = extractor.execute(image_1, label_1)\n",
     "result_2 = extractor.execute(image_2, label_2)"
    ]
@@ -239,7 +240,6 @@
     }
    ],
    "source": [
-    "\n",
     "plt.figure(figsize=(20,20))\n",
     "plt.subplot(3,1,1)\n",
     "plt.plot(feature_1)\n",
@@ -255,7 +255,7 @@
     "plt.plot(feature_1 - feature_2)\n",
     "plt.yscale('log')\n",
     "plt.title ( \"Difference\")\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   }
  ],
@@ -268,7 +268,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",


### PR DESCRIPTION
See also [#433](https://github.com/jupyter/docker-stacks/pull/433) on jupyter/docker-stack.
Python 2 support is now removed from jupyter/datascience-notebook. Update dockerfile and config.yml to install python2 kernel manually.