### PR TITLE
Allow a 0 value for output spacing when resampling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ New Features
 - Add a row by row customization of the extraction label in the batch processing command line script, as well as both
   batchprocessing examples.
   (`#262 <https://github.com/Radiomics/pyradiomics/pull/262>`_)
+- Allow value 0 for a resampled pixel spacing (per dimension). Values of 0 are replaced by the spacing for that
+  dimension as it is in the original (non-resampled) mask. This allows resampling over a subset of dimension (e.g. only
+  in-plane resampling when out-of-plane spacing is set to 0).
+  (`#299 <https://github.com/Radiomics/pyradiomics/pull/299>`_)
 
 Bug fixes
 #########

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -128,7 +128,9 @@ Feature Extractor Level
 
 *Resampling the image*
 
-- resampledPixelSpacing [None]: List of 3 floats (> 0), sets the size of the voxel in (x, y, z) plane when resampling.
+- resampledPixelSpacing [None]: List of 3 floats (>= 0), sets the size of the voxel in (x, y, z) plane when resampling.
+  A value of 0 is replaced with the spacing for that dimension as it is in the original (non-resampled) mask, thereby
+  enabling only in-plane resampling, for example.
 - interpolator [sitkBSpline]: Simple ITK constant or string name thereof, sets interpolator to use for resampling.
   Enumerated value, possible values:
 

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -43,9 +43,9 @@ mapping:
           min-ex: 0
       resampledPixelSpacing:
         seq:
-          - type: int
+          - type: float
             range:
-              min-ex: 0
+              min: 0
       interpolator:
         type: any
         func: checkInterpolator


### PR DESCRIPTION
When resampling, allow the output spacing for any dimension to be set to 0 (the parameter 'resampledPixelSpacing' still needs to be a sequence of 3 elements, but the value of any element can be 0). Doing so will enable 'preserving' the original spacing, as 0 values are replaced with the spacing for that dimension as it is in the original (non-resampled) mask. This way, it is possible to only resample in-plane (by setting the out-of-plane output spacing to 0).

Additionally, move the check between original and resampled spacing to after the size check (no resampling over dimensions for which bounding box size = 1) and build in a tolerance (1e-5 + 1e-8 * abs(resampledspacing)).

Finally, fix data type for resampled spacing in the validation schema for parameter files (change from integer to float).