### PR TITLE
Add optional resegmentation of mask

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -154,6 +154,17 @@ Feature Extractor Level
 .. note::
     Resampling is disabled when either `resampledPixelSpacing` or `interpolator` is set to `None`
 
+*Resegmentation*
+
+- resegmentRange [None]: List of 2 floats, specifies the lower and upper threshold, respectively. Segmented voxels
+  outside this range are removed from the mask prior to feature calculation. When the value is None (default), no
+  resegmentation is performed. Resegemented size is checked (using parameter ``minimumROISize``, default 1) and upon
+  fail, an error is logged and the mask is reset to the original mask.
+
+.. note::
+    This only affects first order and texture classes. No resegmentation is performed prior to calculating shape
+    features.
+
 *Mask validation*
 
 - minimumROIDimensions [1]: Integer, range 1-3, specifies the minimum dimensions (1D, 2D or 3D, respectively).
@@ -237,6 +248,7 @@ Feature Class Level
     This only affects the GLCM and GLRLM feature classes. Moreover, weighting is applied differently in those classes.
     For more information on how weighting is applied, see the documentation on :ref:`GLCM <radiomics-glcm-label>` and
     :ref:`GLRLM <radiomics-glszm-label>`.
+
 
 Feature Class Specific Settings
 +++++++++++++++++++++++++++++++

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -65,6 +65,9 @@ mapping:
         range:
           min: 0
           max: 2
+      resegmentRange:
+        seq:
+          - type: float
       sigma:
         seq:
           - type: float


### PR DESCRIPTION
Add functionality to resegment the mask prior to calculation of features (ony applies to firstorder / texture, no resegmentation possible prior to shape feature calculation). Introduces new parameter `resegmentRange`, a list of 2 floats which define the lower and upper threshold, respectively. Values outside the range specified are removed from the mask. After successful resegmentation, the resultant mask is rechecked to ensure it is still valid (using function `imageoperations.checkMask()`). A value of None (the default value) for the parameter `resegmentRange` disables resegmentation.

cc @Radiomics/developers 