### PR TITLE
Add additional checks to batch processing script

### DIFF
--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -415,7 +415,7 @@ class RadiomicsFeaturesExtractor:
     padding as specified in padDistance) after assignment of image and mask.
     """
     self.logger.info('Loading image and mask')
-    if isinstance(ImageFilePath, six.string_types) and os.path.exists(ImageFilePath):
+    if isinstance(ImageFilePath, six.string_types) and os.path.isfile(ImageFilePath):
       image = sitk.ReadImage(ImageFilePath)
     elif isinstance(ImageFilePath, sitk.SimpleITK.Image):
       image = ImageFilePath
@@ -423,7 +423,7 @@ class RadiomicsFeaturesExtractor:
       self.logger.warning('Error reading image Filepath or SimpleITK object')
       return None, None  # this function is expected to always return a tuple of 2 elements
 
-    if isinstance(MaskFilePath, six.string_types) and os.path.exists(MaskFilePath):
+    if isinstance(MaskFilePath, six.string_types) and os.path.isfile(MaskFilePath):
       mask = sitk.ReadImage(MaskFilePath)
     elif isinstance(MaskFilePath, sitk.SimpleITK.Image):
       mask = MaskFilePath


### PR DESCRIPTION
Add additional checks to ensure required columns are present and have a value for each case. If columns are missing, log an error and exit. If cells in required column have missing values (empty strings), log an error and skip to next case.

Also update the image and mask filepath if the path is relative, as it is assumed to be relative to the input file, not the current working directory.

Finally replace `os.path.exists` with `os.path.isfile` in `featureextractor.py`, as a directory is also an existing path, but should not be used during attempt to load using SimpleITK.