### PR TITLE
Remove 32 bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Furthermore, an instruction video is available [here](http://radiomics.io/pyradi
 
 ### Installation
 
-PyRadiomics is OS independent and compatible with both Python 2.7 and Python >=3.4.
+PyRadiomics is OS independent and compatible with both Python 2.7 and Python >=3.4 (64-bits).
 To install this package on unix like systems run the following commands from the root directory:
 
     python -m pip install -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,30 +7,16 @@ version: "0.0.1.{build}"
 environment:
   matrix:
 
-    # Visual Studio (Python 2 & 3, 32 & 64 bit)
-    - PYTHON_DIR: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-      BLOCK: "0"
+    # Visual Studio (Python 2 & 3, 64 bit)
 
     - PYTHON_DIR: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       BLOCK: "0"
 
-    - PYTHON_DIR: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-      BLOCK: "0"
-
     - PYTHON_DIR: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
-      BLOCK: "0"
-
-    - PYTHON_DIR: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
       BLOCK: "0"
 
     - PYTHON_DIR: "C:\\Python35-x64"

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -203,9 +203,9 @@ To ensure consistency in the extraction provided by PyRadiomics, continuous test
 source code after each commit. These tests are defined in the test folder and used to run tests for the following
 environments:
 
-    - Python 2.7 32 and 64 bits (Windows, Linux and Mac)
-    - Python 3.4 32 and 64 bits (Windows and Linux)
-    - Python 3.5 32 and 64 bits (Windows and Linux)
+    - Python 2.7 64 bits (Windows, Linux and Mac)
+    - Python 3.4 64 bits (Windows and Linux)
+    - Python 3.5 64 bits (Windows and Linux)
 
 .. note::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -29,7 +29,7 @@ Which python versions is PyRadiomics compatible with?
 #####################################################
 
 PyRadiomics is compatible with both python 2 and python 3. The automated testing uses python versions 2.7, 3.4 and 3.5
-(both 32 and 64 bits). Python < 2.6 is not supported. Other python versions may be compatible with PyRadiomics, but this
+(only 64 bits architecture). Python < 2.6 is not supported. Other python versions may be compatible with PyRadiomics, but this
 is not actively tested and therefore not guaranteed to work.
 
 Input / Customization

--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -15,8 +15,6 @@ import numpy  # noqa: F401
 
 from . import imageoperations
 
-if sys.version_info < (2, 6, 0):
-  raise ImportError("pyradiomics > 0.9.7 requires python 2.6 or later")
 
 def setVerbosity(level):
   """

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,55 @@
 #!/usr/bin/env python
 
 from distutils import sysconfig
+import platform
+import sys
 
 import numpy
 
 from setuptools import Extension, setup
-
 from setuptools.command.test import test as TestCommand
-
 
 import versioneer
 
+# Check if current PyRadiomics is compatible with current python installation (> 2.6, 64 bits)
+if sys.version_info < (2, 6, 0):
+  raise Exception("pyradiomics > 0.9.7 requires python 2.6 or later")
+
+if platform.architecture()[0].startswith('32'):
+  raise Exception('PyRadiomics requires 64 bits python')
+
 with open('requirements.txt', 'r') as fp:
-    requirements = list(filter(bool, (line.strip() for line in fp)))
+  requirements = list(filter(bool, (line.strip() for line in fp)))
 
 with open('requirements-dev.txt', 'r') as fp:
-    dev_requirements = list(filter(bool, (line.strip() for line in fp)))
+  dev_requirements = list(filter(bool, (line.strip() for line in fp)))
 
 with open('requirements-setup.txt', 'r') as fp:
-    setup_requirements = list(filter(bool, (line.strip() for line in fp)))
+  setup_requirements = list(filter(bool, (line.strip() for line in fp)))
+
 
 class NoseTestCommand(TestCommand):
-    """Command to run unit tests using nose driver after in-place build"""
+  """Command to run unit tests using nose driver after in-place build"""
 
-    user_options = TestCommand.user_options + [
-        ("args=", None, "Arguments to pass to nose"),
-    ]
+  user_options = TestCommand.user_options + [
+    ("args=", None, "Arguments to pass to nose"),
+  ]
 
-    def initialize_options(self):
-        self.args = []
-        TestCommand.initialize_options(self)
+  def initialize_options(self):
+    self.args = []
+    TestCommand.initialize_options(self)
 
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        if self.args:
-            self.args = __import__('shlex').split(self.args)
+  def finalize_options(self):
+    TestCommand.finalize_options(self)
+    if self.args:
+      self.args = __import__('shlex').split(self.args)
 
-    def run_tests(self):
-        # Run nose ensuring that argv simulates running nosetests directly
-        nose_args = ['nosetests']
-        nose_args.extend(self.args)
-        __import__('nose').run_exit(argv=nose_args)
+  def run_tests(self):
+    # Run nose ensuring that argv simulates running nosetests directly
+    nose_args = ['nosetests']
+    nose_args.extend(self.args)
+    __import__('nose').run_exit(argv=nose_args)
+
 
 commands = versioneer.get_cmdclass()
 commands['test'] = NoseTestCommand
@@ -53,49 +62,49 @@ ext = [Extension("radiomics._cmatrices", ["radiomics/src/_cmatrices.c", "radiomi
                  include_dirs=incDirs)]
 
 setup(
-    name='pyradiomics',
+  name='pyradiomics',
 
-    url='http://github.com/Radiomics/pyradiomics#readme',
+  url='http://github.com/Radiomics/pyradiomics#readme',
 
-    author='pyradiomics community',
-    author_email='pyradiomics@googlegroups.com',
+  author='pyradiomics community',
+  author_email='pyradiomics@googlegroups.com',
 
-    version=versioneer.get_version(),
-    cmdclass=commands,
+  version=versioneer.get_version(),
+  cmdclass=commands,
 
-    packages=['radiomics', 'radiomics.scripts'],
-    ext_modules=ext,
-    zip_safe=False,
-    package_data={'radiomics': ['schemas/paramSchema.yaml', 'schemas/schemaFuncs.py']},
+  packages=['radiomics', 'radiomics.scripts'],
+  ext_modules=ext,
+  zip_safe=False,
+  package_data={'radiomics': ['schemas/paramSchema.yaml', 'schemas/schemaFuncs.py']},
 
-    entry_points={
-        'console_scripts': [
-            'pyradiomics=radiomics.scripts.commandline:main',
-            'pyradiomicsbatch=radiomics.scripts.commandlinebatch:main'
-        ]},
+  entry_points={
+    'console_scripts': [
+      'pyradiomics=radiomics.scripts.commandline:main',
+      'pyradiomicsbatch=radiomics.scripts.commandlinebatch:main'
+    ]},
 
-    description='Radiomics features library for python',
-    license='BSD License',
+  description='Radiomics features library for python',
+  license='BSD License',
 
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: C',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
-    ],
+  classifiers=[
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: OS Independent',
+    'Programming Language :: C',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Topic :: Scientific/Engineering :: Bio-Informatics',
+  ],
 
-    keywords='radiomics cancerimaging medicalresearch computationalimaging',
+  keywords='radiomics cancerimaging medicalresearch computationalimaging',
 
-    install_requires=requirements,
-    test_suite='nose.collector',
-    tests_require=dev_requirements,
-    setup_requires=setup_requirements
+  install_requires=requirements,
+  test_suite='nose.collector',
+  tests_require=dev_requirements,
+  setup_requires=setup_requirements
 )


### PR DESCRIPTION
When using PyRadiomics in 32 bits architecture, memory errors can arise when extracting large masks, or many small ones (see also #303).
Therefore, remove support for 32 bits architecture by raising an exception when trying to install PyRadiomics on 32 bits architecture.

Update documentation accordingly.
Reformat `setup.py` script to adhere to editorconfig settings

cc @Radiomics/developers, @michaelschwier