### PR TITLE
Add pre-cropping

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -154,6 +154,17 @@ Feature Extractor Level
 .. note::
     Resampling is disabled when either `resampledPixelSpacing` or `interpolator` is set to `None`
 
+*Pre-Cropping*
+
+- preCrop [False]: Boolean, if true and resampling is disabled, crops the image onto the bounding box with additional
+  padding as specified in ``padDistance``. Similar to padding after resampling, padding does not exceed original image
+  bounds after pre-cropping. Setting ``preCrop`` to true speeds up extraction and makes it less memory intensive,
+  especially in the case of large images with only small ROIs.
+
+.. note::
+  Because image and mask are also cropped onto the bounding box before they are passed to the feature classes,
+  pre-crop is only beneficial when filters are enabled.
+
 *Resegmentation*
 
 - resegmentRange [None]: List of 2 floats, specifies the lower and upper threshold, respectively. Segmented voxels

--- a/examples/exampleSettings/exampleMR_NoResampling.yaml
+++ b/examples/exampleSettings/exampleMR_NoResampling.yaml
@@ -75,7 +75,9 @@ setting:
 
   # Resampling:
   # Not enabled in this example. However, because texture calculation assumes isotropic spacing, a forced 2D extraction
-  # is used, therefore only requiring the voxels to be isotropic in-plane.
+  # is used, therefore only requiring the voxels to be isotropic in-plane. Enable pre-cropping to reduce memory
+  # footprint and speed up applying the filters.
+  preCrop: true
 
   # Forced 2D extracion:
   # This allows to calculate texture features using anisotropic voxels (although it assumes that voxels are isotropic

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -85,6 +85,7 @@ class RadiomicsFeaturesExtractor:
             'removeOutliers': None,
             'resampledPixelSpacing': None,  # No resampling by default
             'interpolator': 'sitkBSpline',  # Alternative: sitk.sitkBSpline
+            'preCrop': False,
             'padDistance': 5,
             'distances': [1],
             'force2D': False,
@@ -446,6 +447,15 @@ class RadiomicsFeaturesExtractor:
                                                   self.settings['interpolator'],
                                                   self.settings['label'],
                                                   self.settings['padDistance'])
+    elif self.settings['preCrop']:
+      bb, correctedMask = imageoperations.checkMask(image, mask, **self.settings)
+      if correctedMask is not None:
+        # Update the mask if it had to be resampled
+        mask = correctedMask
+      if bb is None:
+        # Mask checks failed
+        return None, None
+      image, mask = imageoperations.cropToTumorMask(image, mask, bb, self.settings['padDistance'])
 
     return image, mask
 

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -363,7 +363,7 @@ def _checkROI(imageNode, maskNode, label):
   return bb
 
 
-def cropToTumorMask(imageNode, maskNode, boundingBox):
+def cropToTumorMask(imageNode, maskNode, boundingBox, padDistance=0):
   """
   Create a sitkImage of the segmented region of the image based on the input label.
 
@@ -382,8 +382,12 @@ def cropToTumorMask(imageNode, maskNode, boundingBox):
   maskNode = sitk.Cast(maskNode, sitk.sitkInt32)
   size = numpy.array(maskNode.GetSize())
 
-  ijkMinBounds = boundingBox[0::2]
-  ijkMaxBounds = size - boundingBox[1::2] - 1
+  ijkMinBounds = boundingBox[0::2] - padDistance
+  ijkMaxBounds = size - boundingBox[1::2] - padDistance - 1
+
+  # Ensure cropped area is not outside original image bounds
+  ijkMinBounds = numpy.maximum(ijkMinBounds, 0)
+  ijkMaxBounds = numpy.maximum(ijkMaxBounds, 0)
 
   # Crop Image
   logger.debug('Cropping to size %s', (boundingBox[1::2] - boundingBox[0::2]) + 1)

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -68,6 +68,8 @@ mapping:
       resegmentRange:
         seq:
           - type: float
+      preCrop:
+        type: bool
       sigma:
         seq:
           - type: float


### PR DESCRIPTION
When resampling is enabled, image and mask are pre-cropped onto the bounding box (with additional padding). This speeds up the resampling process and the application of filters. Moreover, it can significantly reduce the memory footprint of the extraction, especially when the images are large, but contain only small ROIs.
Add functionality to also pre-crop the image when no resampling is applied. This way, the advantages when applying filters on a pre-cropped image and mask are also available when extracting without resampling.

Similar as pre-cropping when resampling, additional padding is available (parameter `padDistance`), which is ensure to not exceed the original image bounds.

cc @Radiomics/developers