### PR TITLE
Fix incorrect usage of self.maskArray

### DIFF
--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -78,7 +78,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
 
     # Set voxels outside delineation to padding value
     padVal = numpy.nan
-    self.matrix[(self.maskArray != self.label)] = padVal
+    self.matrix[~self.maskArray] = padVal
 
     angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
     angles = numpy.concatenate((angles, angles * -1))
@@ -109,7 +109,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
         depMat[~nanMask] += (numpy.abs(angMat[~nanMask]) <= self.gldm_a)
 
     grayLevels = self.coefficients['grayLevels']
-    dependenceSizes = numpy.unique(depMat[self.labelledVoxelCoordinates])
+    dependenceSizes = numpy.unique(depMat[self.maskArray])
     P_gldm = numpy.zeros((len(grayLevels), len(dependenceSizes)))
 
     with self.progressReporter(grayLevels, desc='calculate GLDM') as bar:

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -133,7 +133,7 @@ class RadiomicsTestUtils:
                                                                 interpolator,
                                                                 self._kwargs.get('label', 1),
                                                                 self._kwargs.get('padDistance', 5))
-      bb, correctedMask = imageoperations.checkMask(self._image, self._mask)
+      bb, correctedMask = imageoperations.checkMask(self._image, self._mask, **self._kwargs)
       if correctedMask is not None:
         self._mask = correctedMask
       self._image, self._mask = imageoperations.cropToTumorMask(self._image, self._mask, bb)


### PR DESCRIPTION
In full-python calculation of the GLDM matrix, calculation would fail when label != 1. Update GLDM to also work with different mask values.

Fix an additional bug in testUtils, where the Label value stored in the baseline was not passed to the checkMask function when loading a test case.