### PR TITLE
DOCS: Add version of packages used in feature calculation

### DIFF
--- a/radiomics/generalinfo.py
+++ b/radiomics/generalinfo.py
@@ -1,6 +1,8 @@
 import collections
 import logging
 
+import numpy
+import pywt
 import SimpleITK as sitk
 import six
 
@@ -123,6 +125,24 @@ class GeneralInfo():
     Return the current version of this package.
     """
     return radiomics.__version__
+
+  def getNumpyVersionValue(self):
+    """
+    Return the current version of the numpy package, used for feature calculation.
+    """
+    return numpy.__version__
+
+  def getSimpleITKVersionValue(self):
+    """
+    Return the current version of the SimpleITK package, used for image processing.
+    """
+    return sitk.Version().VersionString()
+
+  def getPyWaveletVersionValue(self):
+    """
+    Return the current version of the PyWavelet package, used to apply the wavelet filter.
+    """
+    return pywt.__version__
 
   def getVolumeNumValue(self):
     """


### PR DESCRIPTION
Add versions of SimpleITK, Numpy and PyWavelet to the additional info output. PyRadiomics uses these 3 packages to process the images and calculate the features.

Fixes #341.
cc @Radiomics/developers 