### PR TITLE
BUG: Fixed resizing for wavelet filtering (resizing was scrambling image)

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -745,9 +745,9 @@ def _swt3(inputImage, wavelet='coif1', level=1, start_level=0, axes=(2, 1, 0)):
     raise ValueError('Expected 3D data array')
 
   original_shape = matrix.shape
-  adjusted_shape = tuple([dim + 1 if dim % 2 != 0 else dim for dim in original_shape])
+  padding = tuple([(0, 1 if dim % 2 != 0 else 0) for dim in original_shape])
   data = matrix.copy()
-  data.resize(adjusted_shape, refcheck=False)
+  data = numpy.pad(data, padding, 'constant')
 
   if not isinstance(wavelet, pywt.Wavelet):
     wavelet = pywt.Wavelet(wavelet)
@@ -764,14 +764,14 @@ def _swt3(inputImage, wavelet='coif1', level=1, start_level=0, axes=(2, 1, 0)):
     dec_im = {}
     for decName, decImage in six.iteritems(dec):
       decTemp = decImage.copy()
-      decTemp = numpy.resize(decTemp, original_shape)
+      decTemp = decTemp[[slice(None, -1 if dim % 2 != 0 else None) for dim in original_shape]]
       sitkImage = sitk.GetImageFromArray(decTemp)
       sitkImage.CopyInformation(inputImage)
       dec_im[str(decName).replace('a', 'L').replace('d', 'H')] = sitkImage
 
     ret.append(dec_im)
 
-  data = numpy.resize(data, original_shape)
+  data = data[[slice(None, -1 if dim % 2 != 0 else None) for dim in original_shape]]
   approximation = sitk.GetImageFromArray(data)
   approximation.CopyInformation(inputImage)
 

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -747,7 +747,7 @@ def _swt3(inputImage, wavelet='coif1', level=1, start_level=0, axes=(2, 1, 0)):
   original_shape = matrix.shape
   padding = tuple([(0, 1 if dim % 2 != 0 else 0) for dim in original_shape])
   data = matrix.copy()
-  data = numpy.pad(data, padding, 'constant')
+  data = numpy.pad(data, padding, 'wrap')
 
   if not isinstance(wavelet, pywt.Wavelet):
     wavelet = pywt.Wavelet(wavelet)


### PR DESCRIPTION
The resizing in `_swt3`, which is called by `getWaveletImage` to extend images to ensure image dims are multiples of 2, causes images to be scrambled, because numpy's `resize` simply adds zeros at the end of the buffer and changes the shape of the array (see [here](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.resize.html), esp. example 3).

Hence for enlarging we need to use `numpy.pad` and for shrinking back we need to use slicing (see fixed code).

This causes the wavelet results to be wrong for all images/ROIs with an odd dimension (actually for only odd z it might not be, because in this case the resize "accidentally" has the expected behavior).

All the above insights and the fixed code is courtesy of Jan Moltz/Fraunhofer MEVIS, who tracked this bug down.

To reproduce and test the bug/bugfix I created test data and implemented a little test, which you can find [here](https://www.dropbox.com/sh/5ijirs4hpbblomu/AADR0MqR2SgSRbK7bZvrr5Zra?dl=0). 
If you run the python file, it will write a "test_out.csv" with the extracted features for different images and crop settings. It will also print all features which have different outcomes among the test images/settings and the  max abs difference.

PS: You will see that the LoG filter also causes differences, but rather small ones. I assume this is expected since the ITK filter used probably doesn't use a fixed kernel size but tries to approximate a real gaussian filter. However, we might consider if this is behavior we want/accept for radiomics or if we would prefer perfectly reproducible feature values.