### PR TITLE
BUG: Fix machine precision errors in eigen value calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,8 @@ Bug fixes
   (`#287 <https://github.com/Radiomics/pyradiomics/pull/287>`_)
 - For GLRLM and GLSZM, force2D keyword is passed manually, but was incorrectly named and therefore ignored. Fix name to
   enable forced 2D extraction for GLRLM and GLSZM. (`26b9ef3 <https://github.com/Radiomics/pyradiomics/commit/26b9ef3>`_)
+- Fix bug in the calculation of eigen values due to machine precision errors.
+  (`#355 <https://github.com/Radiomics/pyradiomics/pull/355>`_)
 
 Tests
 #####


### PR DESCRIPTION
If the segmentation in the dataset represents a 2D segmentation, the smallest of the 3 eigenvectors should be 0.
But because a transform to physical coordinates (taking into account rotation and scaling), this can actually compute very small (~1e-16) negative numbers.

This in turn causes an error in numpy.sqrt. This commit implements a 3-fold fix.

1) Because we do not need the eigen vectors, we can also calculate the eigenvalues using just the scaled coordinates, without rotation. In case of a 2D segmentation, this then results in correct calculation of 0 for the smallest eigen value.
2) After computation of eigen values. They are checked if they are negative, but > -1e-10. If that is the case, a warning is logged and they are rounded to 0.
3) Add additional checks to ensure the eigenvectors are not < 0 (effectively < -1e-10) in the feature functions. If that is the case, a warning is logged and nan is returned.