### PR TITLE
Add the Gradient Magnitude image filter.

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -63,6 +63,7 @@ Currently available image types are:
   negative original values are made negative again after application of filter.
 - Exponential: Takes the the exponential, where filtered intensity is e^(absolute intensity). Values are
   scaled to original range and negative original values are made negative again after application of filter.
+- Gradient: Returns the magnitude of the local gradient. See also :py:func:`~radiomics.imageoperations.getGradientImage`
 
 .. _radiomics-feature-classes-label:
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -241,6 +241,11 @@ Filter Level
     - bior[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
     - rbio[1.1, 1.3, 1.5, 2.2, 2.4, 2.6, 2.8, 3.1, 3.3, 3.5, 3.7, 3.9, 4.4, 5.5, 6.8]
 
+*Gradient settings*
+
+- ``gradientUseSpacing`` [True]: Boolean, if true, image spacing is taken into account when computing the
+  gradient magnitude in the image.
+
 Feature Class Level
 +++++++++++++++++++
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ Aside from the feature classes, there are also some built-in optional filters:
 * :py:func:`Square Root <radiomics.imageoperations.getSquareRootImage>`
 * :py:func:`Logarithm <radiomics.imageoperations.getLogarithmImage>`
 * :py:func:`Exponential <radiomics.imageoperations.getExponentialImage>`
+* :py:func:`Gradient <radiomics.imageoperations.getGradientImage>`
 
 For more information, see also :ref:`radiomics-imageoperations-label`.
 

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -915,3 +915,15 @@ def getExponentialImage(inputImage, **kwargs):
 
   logger.debug('Yielding exponential image')
   yield im, 'exponential', kwargs
+
+
+def getGradientImage(inputImage, **kwargs):
+  r"""
+  Compute and return the Gradient Magnitude in the image.
+  By default, takes into account the image spacing, this can be switched off by specifying
+  ``gradientUseSpacing = False``.
+  """
+  gmif = sitk.GradientMagnitudeImageFilter()
+  gmif.SetUseImageSpacing(kwargs.get('gradientUseSpacing', True))
+  im = gmif.Execute(inputImage)
+  yield im, 'gradient', kwargs

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -86,6 +86,8 @@ mapping:
       wavelet:
         type: str
         func: checkWavelet
+      gradientUseSpacing:
+        type: bool
       voxelArrayShift:
         type: int
       symmetricalGLCM:


### PR DESCRIPTION
Returns an image with the gradient magnitude as voxel value.
Adds parameter `gradientUseSpacing`, which controls whether or not to take image spacing into account when computing the gradient.