### PR TITLE
Add Local Binary Pattern Image Filter

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -64,6 +64,8 @@ Currently available image types are:
 - Exponential: Takes the the exponential, where filtered intensity is e^(absolute intensity). Values are
   scaled to original range and negative original values are made negative again after application of filter.
 - Gradient: Returns the magnitude of the local gradient. See also :py:func:`~radiomics.imageoperations.getGradientImage`
+- LocalBinaryPattern2D: Computes the Local Binary Pattern in a by-slice operation (2D).
+  See also :py:func:`~radiomics.imageoperations.getLBP2DImage`
 
 .. _radiomics-feature-classes-label:
 
@@ -246,6 +248,15 @@ Filter Level
 
 - ``gradientUseSpacing`` [True]: Boolean, if true, image spacing is taken into account when computing the
   gradient magnitude in the image.
+
+*Local Binary Pattern 2D*
+
+- ``lbp2DRadius`` [1]: Float, specifies the radius in which the neighbours should be sampled
+- ``lbp2DSamples`` [9]: Integer, specifies the number of samples to use
+- ``lbp2DMethod`` ['uniform']: String, specifies the method for computing the LBP to use.
+
+.. warning::
+  Requires package ``skimage`` to function.
 
 Feature Class Level
 +++++++++++++++++++

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -66,6 +66,9 @@ Currently available image types are:
 - Gradient: Returns the magnitude of the local gradient. See also :py:func:`~radiomics.imageoperations.getGradientImage`
 - LocalBinaryPattern2D: Computes the Local Binary Pattern in a by-slice operation (2D).
   See also :py:func:`~radiomics.imageoperations.getLBP2DImage`
+- LocalBinaryPattern3D: Computes the Local Binary Pattern in 3D using spherical harmonics.
+  See also :py:func:`~radiomics.imageoperations.getLBP3DImage`
+
 
 .. _radiomics-feature-classes-label:
 
@@ -251,12 +254,22 @@ Filter Level
 
 *Local Binary Pattern 2D*
 
-- ``lbp2DRadius`` [1]: Float, specifies the radius in which the neighbours should be sampled
-- ``lbp2DSamples`` [9]: Integer, specifies the number of samples to use
+- ``lbp2DRadius`` [1]: Float, > 0, specifies the radius in which the neighbours should be sampled
+- ``lbp2DSamples`` [9]: Integer, :math:`\geq 1`, specifies the number of samples to use
 - ``lbp2DMethod`` ['uniform']: String, specifies the method for computing the LBP to use.
 
 .. warning::
   Requires package ``skimage`` to function.
+
+*Local Binary Pattern 3D*
+
+- ``lbp3DLevels`` [2]: integer, :math:`\geq 1`, specifies the the number of levels in spherical harmonics to use.
+- ``lbp3DIcosphereRadius`` [1]: Float, > 0, specifies the radius in which the neighbours should be sampled
+- ``lbp3DIcosphereSubdivision`` [1]: Integer, :math:`\geq 0`, specifies the number of subdivisions to apply in the
+  icosphere
+
+.. warning::
+  Requires package ``scipy`` and ``trimesh`` to function.
 
 Feature Class Level
 +++++++++++++++++++

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -84,10 +84,11 @@ Signature of an image type
 --------------------------
 
 All image types are defined in the :ref:`imageoperations module<radiomics-imageoperations-label>`, and identified by the
-signature ``get[Name]Image(inputImage, **kwargs)``. Here, ``[Name]`` represents the unique name for the image type,
-which is also used to identify the image type during extraction. The input of a image type function is fixed and
-consists of the ``inputImage``, a SimpleITK Image object of the original image and ``**kwargs``, which are the
-customized settings that should be used for the extraction of features from the derived image.
+signature ``get[Name]Image(inputImage, inputMask, **kwargs)``. Here, ``[Name]`` represents the unique name for the image
+type, which is also used to identify the image type during extraction. The input of a image type function is fixed and
+consists of the ``inputImage`` and ``inputMask``, SimpleITK Image objects of the original image and mask, respectively
+and ``**kwargs``, which are the customized settings that should be used for the extraction of features from the derived
+image.
 
 One or more derived images are returned using the 'yield' statement: ``yield derivedImage, imageTypeName, kwargs``.
 Here, ``derivedImage`` is one SimpleITK image object representing the filtered image, ``imageTypeName`` is a unique

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -7,13 +7,13 @@ Radiomic Features
 This section contains the definitions of the various features that can be extracted using PyRadiomics. They are
 subdivided into the following classes:
 
-* :ref:`radiomics-firstorder-label` (19 features)
-* :ref:`radiomics-shape-label` (16 features)
-* :ref:`radiomics-glcm-label` (23 features)
-* :ref:`radiomics-glszm-label` (16 features)
-* :ref:`radiomics-glrlm-label` (16 features)
-* :ref:`radiomics-ngtdm-label` (5 features)
-* :ref:`radiomics-gldm-label` (14 features)
+* :py:class:`First Order Statistics <radiomics.firstorder.RadiomicsFirstOrder>` (19 features)
+* :py:class:`Shape-based <radiomics.shape.RadiomicsShape>` (16 features)
+* :py:class:`Gray Level Cooccurence Matrix <radiomics.glcm.RadiomicsGLCM>` (23 features)
+* :py:class:`Gray Level Run Length Matrix <radiomics.glrlm.RadiomicsGLRLM>` (16 features)
+* :py:class:`Gray Level Size Zone Matrix <radiomics.glszm.RadiomicsGLSZM>` (16 features)
+* :py:class:`Neigbouring Gray Tone Difference Matrix <radiomics.ngtdm.RadiomicsNGTDM>` (5 features)
+* :py:class:`Gray Level Dependence Matrix <radiomics.gldm.RadiomicsGLDM>` (14 features)
 
 All feature classes, with the exception of shape can be calculated on either the original image and/or a derived image,
 obtained by applying one of several filters. The shape descriptors are independent of gray value, and are extracted from

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,13 +57,13 @@ Feature Classes
 
 Currently supports the following feature classes:
 
-* :ref:`First Order Statistics <radiomics-firstorder-label>`
-* :ref:`Shape-based <radiomics-shape-label>`
-* :ref:`Gray Level Cooccurence Matrix <radiomics-glcm-label>` (GLCM)
-* :ref:`Gray Level Run Length Matrix <radiomics-glrlm-label>` (GLRLM)
-* :ref:`Gray Level Size Zone Matrix <radiomics-glszm-label>` (GLSZM)
-* :ref:`Neigbouring Gray Tone Difference Matrix <radiomics-ngtdm-label>` (NGTDM)
-* :ref:`Gray Level Dependence Matrix <radiomics-gldm-label>` (GLDM)
+* :py:class:`First Order Statistics <radiomics.firstorder.RadiomicsFirstOrder>`
+* :py:class:`Shape-based <radiomics.shape.RadiomicsShape>`
+* :py:class:`Gray Level Cooccurence Matrix <radiomics.glcm.RadiomicsGLCM>` (GLCM)
+* :py:class:`Gray Level Run Length Matrix <radiomics.glrlm.RadiomicsGLRLM>` (GLRLM)
+* :py:class:`Gray Level Size Zone Matrix <radiomics.glszm.RadiomicsGLSZM>` (GLSZM)
+* :py:class:`Neigbouring Gray Tone Difference Matrix <radiomics.ngtdm.RadiomicsNGTDM>` (NGTDM)
+* :py:class:`Gray Level Dependence Matrix <radiomics.gldm.RadiomicsGLDM>` (GLDM)
 
 On average, Pyradiomics extracts :math:`\approx 1500` features per image, which consist of the 16 shape descriptors and
 features extracted from original and derived images (LoG with 5 sigma levels, 1 level of Wavelet decomposistions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ Aside from the feature classes, there are also some built-in optional filters:
 * :py:func:`Exponential <radiomics.imageoperations.getExponentialImage>`
 * :py:func:`Gradient <radiomics.imageoperations.getGradientImage>`
 * :py:func:`Local Binary Pattern (2D) <radiomics.imageoperations.getLBP2DImage>`
+* :py:func:`Local Binary Pattern (3D) <radiomics.imageoperations.getLBP3DImage>`
 
 For more information, see also :ref:`radiomics-imageoperations-label`.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Aside from the feature classes, there are also some built-in optional filters:
 * :py:func:`Logarithm <radiomics.imageoperations.getLogarithmImage>`
 * :py:func:`Exponential <radiomics.imageoperations.getExponentialImage>`
 * :py:func:`Gradient <radiomics.imageoperations.getGradientImage>`
+* :py:func:`Local Binary Pattern (2D) <radiomics.imageoperations.getLBP2DImage>`
 
 For more information, see also :ref:`radiomics-imageoperations-label`.
 

--- a/examples/helloFeatureClass.py
+++ b/examples/helloFeatureClass.py
@@ -148,7 +148,7 @@ for (key, val) in six.iteritems(glszmFeatures.featureValues):
 #
 if applyLog:
   sigmaValues = numpy.arange(5., 0., -.5)[::1]
-  for logImage, imageTypeName, inputKwargs in imageoperations.getLoGImage(image, sigma=sigmaValues):
+  for logImage, imageTypeName, inputKwargs in imageoperations.getLoGImage(image, mask, sigma=sigmaValues):
     logFirstorderFeatures = firstorder.RadiomicsFirstOrder(logImage, mask, **inputKwargs)
     logFirstorderFeatures.enableAllFeatures()
     logFirstorderFeatures.calculateFeatures()
@@ -159,7 +159,7 @@ if applyLog:
 # Show FirstOrder features, calculated on a wavelet filtered image
 #
 if applyWavelet:
-  for decompositionImage, decompositionName, inputKwargs in imageoperations.getWaveletImage(image):
+  for decompositionImage, decompositionName, inputKwargs in imageoperations.getWaveletImage(image, mask):
     waveletFirstOrderFeaturs = firstorder.RadiomicsFirstOrder(decompositionImage, mask, **inputKwargs)
     waveletFirstOrderFeaturs.enableAllFeatures()
     waveletFirstOrderFeaturs.calculateFeatures()

--- a/notebooks/helloFeatureClass.ipynb
+++ b/notebooks/helloFeatureClass.ipynb
@@ -1548,7 +1548,7 @@
    "source": [
     "logFeatures = {}\n",
     "sigmaValues = [1.0, 3.0, 5.0]\n",
-    "for logImage, imageTypename, inputSettings in imageoperations.getLoGImage(image, sigma=sigmaValues):\n",
+    "for logImage, imageTypename, inputSettings in imageoperations.getLoGImage(image, mask, sigma=sigmaValues):\n",
     "  logImage, croppedMask = imageoperations.cropToTumorMask(logImage, mask, bb)\n",
     "  logFirstorderFeatures = firstorder.RadiomicsFirstOrder(logImage, croppedMask, **inputSettings)\n",
     "  logFirstorderFeatures.enableAllFeatures()\n",
@@ -1673,7 +1673,7 @@
    ],
    "source": [
     "waveletFeatures = {}\n",
-    "for decompositionImage, decompositionName, inputSettings in imageoperations.getWaveletImage(image):\n",
+    "for decompositionImage, decompositionName, inputSettings in imageoperations.getWaveletImage(image, mask):\n",
     "  decompositionImage, croppedMask = imageoperations.cropToTumorMask(decompositionImage, mask, bb)\n",
     "  waveletFirstOrderFeaturs = firstorder.RadiomicsFirstOrder(decompositionImage, croppedMask, **inputSettings)\n",
     "  waveletFirstOrderFeaturs.enableAllFeatures()\n",

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -433,7 +433,7 @@ class RadiomicsFeaturesExtractor:
       args = self.settings.copy()
       args.update(customKwargs)
       self.logger.info('Adding image type "%s" with settings: %s' % (imageType, str(args)))
-      imageGenerators = chain(imageGenerators, getattr(imageoperations, 'get%sImage' % imageType)(image, **args))
+      imageGenerators = chain(imageGenerators, getattr(imageoperations, 'get%sImage' % imageType)(image, mask, **args))
 
     self.logger.debug('Extracting features')
     # Calculate features for all (filtered) images in the generator

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -615,7 +615,7 @@ def resegmentMask(imageNode, maskNode, resegmentRange, label=1):
   return newMask
 
 
-def getOriginalImage(inputImage, **kwargs):
+def getOriginalImage(inputImage, inputMask, **kwargs):
   """
   This function does not apply any filter, but returns the original image. This function is needed to
   dynamically expose the original image as a valid image type.
@@ -627,7 +627,7 @@ def getOriginalImage(inputImage, **kwargs):
   yield inputImage, 'original', kwargs
 
 
-def getLoGImage(inputImage, **kwargs):
+def getLoGImage(inputImage, inputMask, **kwargs):
   r"""
   Applies a Laplacian of Gaussian filter to the input image and yields a derived image for each sigma value specified.
 
@@ -708,7 +708,7 @@ def getLoGImage(inputImage, **kwargs):
       logger.warning('applyLoG: sigma must be greater than 0.0: %g', sigma)
 
 
-def getWaveletImage(inputImage, **kwargs):
+def getWaveletImage(inputImage, inputMask, **kwargs):
   """
   Applies wavelet filter to the input image and yields the decompositions and the approximation.
 
@@ -806,7 +806,7 @@ def _swt3(inputImage, wavelet='coif1', level=1, start_level=0, axes=(2, 1, 0)):
   return approximation, ret
 
 
-def getSquareImage(inputImage, **kwargs):
+def getSquareImage(inputImage, inputMask, **kwargs):
   r"""
   Computes the square of the image intensities.
 
@@ -832,7 +832,7 @@ def getSquareImage(inputImage, **kwargs):
   yield im, 'square', kwargs
 
 
-def getSquareRootImage(inputImage, **kwargs):
+def getSquareRootImage(inputImage, inputMask, **kwargs):
   r"""
   Computes the square root of the absolute value of image intensities.
 
@@ -861,7 +861,7 @@ def getSquareRootImage(inputImage, **kwargs):
   yield im, 'squareroot', kwargs
 
 
-def getLogarithmImage(inputImage, **kwargs):
+def getLogarithmImage(inputImage, inputMask, **kwargs):
   r"""
   Computes the logarithm of the absolute value of the original image + 1.
 
@@ -891,7 +891,7 @@ def getLogarithmImage(inputImage, **kwargs):
   yield im, 'logarithm', kwargs
 
 
-def getExponentialImage(inputImage, **kwargs):
+def getExponentialImage(inputImage, inputMask, **kwargs):
   r"""
   Computes the exponential of the original image.
 
@@ -917,7 +917,7 @@ def getExponentialImage(inputImage, **kwargs):
   yield im, 'exponential', kwargs
 
 
-def getGradientImage(inputImage, **kwargs):
+def getGradientImage(inputImage, inputMask, **kwargs):
   r"""
   Compute and return the Gradient Magnitude in the image.
   By default, takes into account the image spacing, this can be switched off by specifying
@@ -929,7 +929,7 @@ def getGradientImage(inputImage, **kwargs):
   yield im, 'gradient', kwargs
 
 
-def getLBP2DImage(inputImage, **kwargs):
+def getLBP2DImage(inputImage, inputMask, **kwargs):
   """
   Compute and return the Local Binary Pattern (LBP) in 2D. If ``force2D`` is set to false (= feature extraction in 3D) a
   warning is logged, as this filter processes the image in a by-slice operation. The plane in which the LBP is
@@ -955,7 +955,7 @@ def getLBP2DImage(inputImage, **kwargs):
   try:
     from skimage.feature import local_binary_pattern
   except ImportError:
-    logger.warning('Could not load required package "skimage", cannot implement filter')
+    logger.warning('Could not load required package "skimage", cannot implement filter LBP 2D')
     return
 
   # Warn the user if features are extracted in 3D, as this function calculates LBP in 2D
@@ -979,3 +979,125 @@ def getLBP2DImage(inputImage, **kwargs):
   im.CopyInformation(inputImage)
 
   yield im, 'lbp-2D', kwargs
+
+
+def getLBP3DImage(inputImage, inputMask, **kwargs):
+  """
+  Compute and return the Local Binary Pattern (LBP) in 3D using spherical harmonics.
+  If ``force2D`` is set to true (= feature extraction in 2D) a warning is logged.
+
+  LBP is only calculated for voxels segmented in the mask
+
+  Following settings are possible:
+
+    - ``lbp3DLevels`` [2]: integer, specifies the the number of levels in spherical harmonics to use.
+    - ``lbp3DIcosphereRadius`` [1]: Float, specifies the radius in which the neighbours should be sampled
+    - ``lbp3DIcosphereSubdivision`` [1]: Integer, specifies the number of subdivisions to apply in the icosphere
+
+  :return: Yields LBP filtered image for each level, 'lbp-3D-m<level>' and ``kwargs`` (customized settings).
+           Additionally yields the kurtosis image, 'lbp-3D-k' and ``kwargs``.
+
+  .. note::
+    LBP can often return only a very small number of different gray levels. A customized bin width is often needed.
+  .. warning::
+    Requires package ``scipy`` and ``trimesh`` to function. If not available, this filter logs a warning and does not
+    yield an image.
+  """
+  global logger
+  try:
+    from scipy.stats import kurtosis
+    from scipy.ndimage.interpolation import map_coordinates
+    from scipy.special import sph_harm
+    from trimesh.creation import icosphere
+  except ImportError:
+    logger.warning('Could not load required package "scipy" or "trimesh", cannot implement filter LBP 3D')
+    return
+
+  # Warn the user if features are extracted in 2D, as this function calculates LBP in 3D
+  if kwargs.get('force2D', False):
+    logger.warning('Calculating Local Binary Pattern in 3D, but extracting features in 2D. Use with caution!')
+
+  label = kwargs.get('label', 1)
+
+  lbp_levels = kwargs.get('lbp3DLevels', 2)
+  lbp_icosphereRadius = kwargs.get('lbp3DIcosphereRadius', 1)
+  lbp_icosphereSubdivision = kwargs.get('lbp3DIcosphereSubdivision', 1)
+
+  im_arr = sitk.GetArrayFromImage(inputImage)
+  ma_arr = sitk.GetArrayFromImage(inputMask)
+
+  # Variables used in the shape comments:
+  # Np Number of voxels
+  # Nv Number of vertices
+
+  # Vertices icosahedron for spherical sampling
+  coords_icosahedron = numpy.array(icosphere(lbp_icosphereSubdivision, lbp_icosphereRadius).vertices)  # shape(Nv, 3)
+
+  # Corresponding polar coordinates
+  theta = numpy.arccos(numpy.true_divide(coords_icosahedron[:, 2], lbp_icosphereRadius))
+  phi = numpy.arctan2(coords_icosahedron[:, 1], coords_icosahedron[:, 0])
+
+  # Corresponding spherical harmonics coefficients Y_{m, n, theta, phi}
+  Y = sph_harm(0, 0, theta, phi)  # shape(Nv,)
+  n_ix = numpy.array(0)
+
+  for n in range(1, lbp_levels):
+    for m in range(-n, n + 1):
+      n_ix = numpy.append(n_ix, n)
+      Y = numpy.column_stack((Y, sph_harm(m, n, theta, phi)))
+  # shape (Nv, x) where x is the number of iterations in the above loops + 1
+
+  # Get labelled coordinates
+  ROI_coords = numpy.where(ma_arr == label)  # shape(3, Np)
+
+  # Interpolate f (samples on the spheres across the entire volume)
+  coords = numpy.array(ROI_coords).T[None, :, :] + coords_icosahedron[:, None, :]  # shape(Nv, Np, 3)
+  f = map_coordinates(im_arr, coords.T, order=3)  # Shape(Np, Nv)  Note that 'Np' and 'Nv' are swapped due to .T
+
+  # Compute spherical Kurtosis
+  k = kurtosis(f, axis=1)  # shape(Np,)
+
+  # Apply sign function
+  f_centroids = im_arr[ROI_coords]  # Shape(Np,)
+  f = numpy.greater_equal(f, f_centroids[:, None]).astype(int)  # Shape(Np, Nv)
+
+  # Compute c_{m,n} coefficients
+  c = numpy.multiply(f[:, :, None], Y[None, :, :])  # Shape(Np, Nv, x)
+  c = c.sum(axis=1)  # Shape(Np, x)
+
+  # Integrate over m
+  f = numpy.multiply(c[:, None, n_ix == 0], Y[None, :, n_ix == 0])  # Shape (Np, Nv, 1)
+  for n in range(1, lbp_levels):
+    f = numpy.concatenate((f,
+                           numpy.sum(numpy.multiply(c[:, None, n_ix == n], Y[None, :, n_ix == n]),
+                                     axis=2, keepdims=True)
+                           ),
+                          axis=2)
+  # Shape f (Np, Nv, levels)
+
+  # Compute L2-Norm
+  f = numpy.sqrt(numpy.sum(f ** 2, axis=1))  # shape(Np, levels)
+
+  # Keep only Real Part
+  f = numpy.real(f)  # shape(Np, levels)
+  k = numpy.real(k)  # shape(Np,)
+
+  # Yield the derived images for each level
+  result = numpy.ndarray(im_arr.shape)
+  for l_idx in range(lbp_levels):
+    result[ROI_coords] = f[:, l_idx]
+
+    # Create a SimpleITK image
+    im = sitk.GetImageFromArray(result)
+    im.CopyInformation(inputImage)
+
+    yield im, 'lbp-3D-m%d' % (l_idx + 1), kwargs
+
+  # Yield Kurtosis
+  result[ROI_coords] = k
+
+  # Create a SimpleITK image
+  im = sitk.GetImageFromArray(result)
+  im.CopyInformation(inputImage)
+
+  yield im, 'lbp-3D-k', kwargs

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -88,6 +88,17 @@ mapping:
         func: checkWavelet
       gradientUseSpacing:
         type: bool
+      lbp2DRadius:
+        type: float
+        range:
+          min-ex: 0
+      lbp2DSamples:
+        type: int
+        range:
+          min: 1
+      lbp2DMethod:
+        type: str
+        enum: ['default', 'ror', 'uniform', 'var']
       voxelArrayShift:
         type: int
       symmetricalGLCM:

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -99,6 +99,18 @@ mapping:
       lbp2DMethod:
         type: str
         enum: ['default', 'ror', 'uniform', 'var']
+      lbp3DLevels:
+        type: int
+        range:
+          min: 1
+      lbp3DIcosphereRadius:
+        type: float
+        range:
+          min-ex: 0
+      lbp3DIcosphereSubdivision:
+        type: int
+        range:
+          min: 0
       voxelArrayShift:
         type: int
       symmetricalGLCM:


### PR DESCRIPTION
Requires `skimage` to function. `skimage` is not added to the requirements and only imported when the function is called. If the package is unavailable, a warning is logged and no image is yielded (does not crash the extraction, but no features for LBP are calculated)