### PR TITLE
Update the validation rule for image types

### DIFF
--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -133,13 +133,7 @@ mapping:
 
   imageType:
     type: map
+    func: checkImageType
+    matching-rule: 'any'
     mapping:
-      # possible image types, it's value is a dictionary (holding image type specific settings) that follows the rules
-      # as in 'setting'
-      Original: *settings
-      LoG: *settings
-      Wavelet: *settings
-      Square: *settings
-      SquareRoot: *settings
-      Logarithm: *settings
-      Exponential: *settings
+       regex;(.+): *settings

--- a/radiomics/schemas/schemaFuncs.py
+++ b/radiomics/schemas/schemaFuncs.py
@@ -1,9 +1,10 @@
 import pywt
 import six
 
-from radiomics import getFeatureClasses
+from radiomics import getFeatureClasses, getImageTypes
 
 featureClasses = getFeatureClasses()
+imageTypes = getImageTypes()
 
 def checkWavelet(value, rule_obj, path):
   if not isinstance(value, six.string_types):
@@ -64,5 +65,18 @@ def checkFeatureClass(value, rule_obj, path):
       unrecognizedFeatures = set(features) - set(featureClasses[className].getFeatureNames())
       if len(unrecognizedFeatures) > 0:
         raise ValueError('Feature Class %s contains unrecognized features: %s' % (className, str(unrecognizedFeatures)))
+
+  return True
+
+
+def checkImageType(value, rule_obj, path):
+  global imageTypes
+  if value is None:
+    raise TypeError('imageType dictionary cannot be None value')
+
+  for im_type in value:
+    if im_type not in imageTypes:
+      raise ValueError('Image Type %s is not recognized. Available image types are %s' %
+                       (im_type, imageTypes))
 
   return True


### PR DESCRIPTION
Before, available filters were hard coded in the `paramSchema.yaml`, requiring the developer to add any new filters explicitly. Change this to use a schema validation rule which checks against the result of `getImageTypes`, which dynamically enumerates the available filters.
Additionally, by applying a regex matching rule that matches any key, the validation rule to test the custom settings is retained.