### PR TITLE
Update c functions

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -170,10 +170,14 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
   def _calculateCMatrix(self):
     self.logger.debug('Calculating GLCM matrix in C')
 
-    angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
     Ng = self.coefficients['Ng']
 
-    P_glcm = cMatrices.calculate_glcm(self.matrix, self.maskArray, angles, Ng)
+    P_glcm, angles = cMatrices.calculate_glcm(self.matrix,
+                                              self.maskArray,
+                                              numpy.array(self.kwargs.get('distances', [1])),
+                                              Ng,
+                                              self.kwargs.get('force2D', False),
+                                              self.kwargs.get('force2Ddimension', 0))
     P_glcm = self._applyMatrixOptions(P_glcm, angles)
 
     # Delete rows and columns that specify gray levels not present in the ROI

--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -138,10 +138,14 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     return P_gldm
 
   def _calculateCMatrix(self):
-    angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
-    Ng = self.coefficients['Ng']
 
-    P_gldm = cMatrices.calculate_gldm(self.matrix, self.maskArray, angles, Ng, self.gldm_a)
+    P_gldm, angles = cMatrices.calculate_gldm(self.matrix,
+                                              self.maskArray,
+                                              numpy.array(self.kwargs.get('distances', [1])),
+                                              self.coefficients['Ng'],
+                                              self.gldm_a,
+                                              self.kwargs.get('force2D', False),
+                                              self.kwargs.get('force2Ddimension', 0))
 
     jvector = numpy.arange(1, P_gldm.shape[1] + 1, dtype='float64')
 

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -169,16 +169,12 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
   def _calculateCMatrix(self):
     self.logger.debug('Calculating GLRLM matrix in C')
-
-    Ng = self.coefficients['Ng']
-    Nr = self.coefficients['Nr']
-
-    # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.boundingBoxSize,
-                                            force2D=self.kwargs.get('force2D', False),
-                                            force2Ddimension=self.kwargs.get('force2Ddimension', 0))
-
-    P_glrlm = cMatrices.calculate_glrlm(self.matrix, self.maskArray, angles, Ng, Nr)
+    P_glrlm, angles = cMatrices.calculate_glrlm(self.matrix,
+                                                self.maskArray,
+                                                self.coefficients['Ng'],
+                                                self.coefficients['Nr'],
+                                                self.kwargs.get('force2D', False),
+                                                self.kwargs.get('force2Ddimension', 0))
     P_glrlm = self._applyMatrixOptions(P_glrlm, angles)
 
     return P_glrlm

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -144,15 +144,15 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
 
   def _calculateCMatrix(self):
     self.logger.debug('Calculating GLSZM matrix in C')
-
-    # Do not pass kwargs directly, as distances may be specified, which must be forced to [1] for this class
-    angles = imageoperations.generateAngles(self.boundingBoxSize,
-                                            force2D=self.kwargs.get('force2D', False),
-                                            force2Ddimension=self.kwargs.get('force2Ddimension', 0))
     Ng = self.coefficients['Ng']
     Ns = self.coefficients['Np']
 
-    P_glszm = cMatrices.calculate_glszm(self.matrix, self.maskArray, angles, Ng, Ns)
+    P_glszm, angles = cMatrices.calculate_glszm(self.matrix,
+                                                self.maskArray,
+                                                Ng,
+                                                Ns,
+                                                self.kwargs.get('force2D', False),
+                                                self.kwargs.get('force2Ddimension', 0))
 
     # Delete rows that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values

--- a/radiomics/ngtdm.py
+++ b/radiomics/ngtdm.py
@@ -172,10 +172,12 @@ class RadiomicsNGTDM(base.RadiomicsFeaturesBase):
     return P_ngtdm
 
   def _calculateCMatrix(self):
-    angles = imageoperations.generateAngles(self.boundingBoxSize, **self.kwargs)
-    Ng = self.coefficients['Ng']
-
-    P_ngtdm = cMatrices.calculate_ngtdm(self.matrix, self.maskArray, angles, Ng)
+    P_ngtdm, angles = cMatrices.calculate_ngtdm(self.matrix,
+                                                self.maskArray,
+                                                numpy.array(self.kwargs.get('distances', [1])),
+                                                self.coefficients['Ng'],
+                                                self.kwargs.get('force2D', False),
+                                                self.kwargs.get('force2Ddimension', 0))
 
     # Delete empty grey levels
     P_ngtdm = numpy.delete(P_ngtdm, numpy.where(P_ngtdm[:, 0] == 0), 0)

--- a/radiomics/src/_cmatrices.c
+++ b/radiomics/src/_cmatrices.c
@@ -9,14 +9,15 @@ static char module_docstring[] = ("This module links to C-compiled code for effi
                                  "in the pyRadiomics package. It provides fast calculation for GLCM, GLDM, NGTDM, "
                                  "GLRLM and GLSZM. All functions are given names as follows: ""calculate_<Matrix>"", "
                                  "where <Matrix> is the name of the matix, in lowercase. Arguments for these functions "
-                                 "are positional and start with 3 numpy arrays (image, mask and angles) and 1 integer "
-                                 "(Ng, number of gray levels). Optionally extra arguments may be required, see function "
-                                 "docstrings for detailed information.");
-static char glcm_docstring[] = "Arguments: Image, Mask, Angles, Ng.";
-static char glszm_docstring[] = "Arguments: Image, Mask, Angles, Ng, Ns, matrix is cropped to maximum size encountered.";
-static char glrlm_docstring[] = "Arguments: Image, Mask, Angles, Ng, Nr.";
-static char ngtdm_docstring[] = "Arguments: Image, Mask, Angles, Ng.";
-static char gldm_docstring[] = "Arguments: Image, Mask, Angles, Ng, Alpha.";
+                                 "are positional and start with 2-3 numpy arrays (image, mask and [distances]) and 3 integers "
+                                 "(Ng number of gray levels, force2D and force2Ddimension). Optionally extra arguments "
+                                 "may be required, see function docstrings for detailed information. "
+                                 "Functions return a tuple with the calculated matrix and angles.");
+static char glcm_docstring[] = "Arguments: Image, Mask, Ng, force2D, for2Ddimension.";
+static char glszm_docstring[] = "Arguments: Image, Mask, Ng, Ns, force2D, for2Ddimension, matrix is cropped to maximum size encountered.";
+static char glrlm_docstring[] = "Arguments: Image, Mask, Ng, Nr, force2D, for2Ddimension.";
+static char ngtdm_docstring[] = "Arguments: Image, Mask, Ng, force2D, for2Ddimension.";
+static char gldm_docstring[] = "Arguments: Image, Mask, Ng, Alpha, force2D, for2Ddimension.";
 
 static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args);
 static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args);
@@ -25,7 +26,7 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args);
 static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args);
 
 // Function to check if array input is valid. Additionally extracts size and stride values
-int check_arrays(PyArrayObject *image_arr, PyArrayObject *mask_arr, PyArrayObject *angles_arr, int *size, int *strides);
+int check_arrays(PyArrayObject *image_arr, PyArrayObject *mask_arr, int *size, int *strides);
 
 static PyMethodDef module_methods[] = {
   //{"calculate_", cmatrices_, METH_VARARGS, _docstring},
@@ -94,57 +95,93 @@ moduleinit(void)
 
 static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
 {
-  int Ng;
-  PyObject *image_obj, *mask_obj, *angles_obj;
-  PyArrayObject *image_arr, *mask_arr, *angles_arr;
-  int Na;
+  int Ng, force2D, force2Ddimension;
+  PyObject *image_obj, *mask_obj, *distances_obj;
+  PyArrayObject *image_arr, *mask_arr, *distances_arr;
+  int n_a, n_dist;
   int size[3];
   int strides[3];
   npy_intp dims[3];
-  PyArrayObject *glcm_arr;
+  PyArrayObject *glcm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *distances, *angles;
   double *glcm;
   int k;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOi", &image_obj, &mask_obj, &angles_obj, &Ng))
+  if (!PyArg_ParseTuple(args, "OOOiii", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension))
     return NULL;
 
   // Interpret the image and mask objects as numpy arrays
   image_arr = (PyArrayObject *)PyArray_FROM_OTF(image_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
   mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BOOL, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-4 if failed.
-  if(check_arrays(image_arr, mask_arr, angles_arr, size, strides) > 0) return NULL;
+  if(check_arrays(image_arr, mask_arr, size, strides) > 0) return NULL;
 
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  // Interpret the distance object as numpy array
+  distances_arr = (PyArrayObject *)PyArray_FROM_OTF(distances_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
+
+  if (distances_arr == NULL)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Error parsing distances array.");
+    return NULL;
+  }
+
+  if (PyArray_NDIM(distances_arr) != 1)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting distances array to be 1-dimensional.");
+    return NULL;
+  }
+
+  // Get the number of distances and the distances array data
+  n_dist = (int)PyArray_DIM(distances_arr, 0);
+  distances = (int *)PyArray_DATA(distances_arr);
+
+  // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
+  if(!force2D) force2Ddimension = -1;
+
+  // Generate the angles needed for texture matrix calculation
+  if (generate_angles(size, distances, 3, n_dist, 0, force2Ddimension, &angles, &n_a) > 0)  // 3D, mono-directional
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting calculating angles.");
+    return NULL;
+  }
+
+  // Clean up distances array
+  Py_XDECREF(distances_arr);
 
   // Initialize output array (elements not set)
   dims[0] = Ng;
   dims[1] = Ng;
-  dims[2] = Na;
+  dims[2] = n_a;
   glcm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
 
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
   glcm = (double *)PyArray_DATA(glcm_arr);
 
   // Set all elements to 0
-  for (k = Ng * Ng * Na - 1; k >= 0; k--) glcm[k] = 0;
+  for (k = Ng * Ng * n_a - 1; k >= 0; k--) glcm[k] = 0;
 
   //Calculate GLCM
-  if (!calculate_glcm(image, mask, size, strides, angles, Na, glcm, Ng))
+  if (!calculate_glcm(image, mask, size, strides, angles, n_a, glcm, Ng))
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     Py_XDECREF(glcm_arr);
+    free(angles);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of GLCM Failed.");
     return NULL;
   }
@@ -152,23 +189,31 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
-  Py_XDECREF(angles_arr);
 
-  return PyArray_Return(glcm_arr);
+  // Wrap angles in a numpy array
+  dims[0] = n_a;
+  dims[1] = 3;
+  angles_arr = (PyArrayObject *)PyArray_SimpleNewFromData(2, dims, NPY_INT, angles);
+
+  // Ensure the Angles array owns the data, so it get's de-allocated when the array is dereferenced
+  PyArray_ENABLEFLAGS(angles_arr, NPY_ARRAY_OWNDATA);
+
+  return Py_BuildValue("OO", PyArray_Return(glcm_arr), PyArray_Return(angles_arr));
 }
 
 static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
 {
-  int Ng, Ns;
-  PyObject *image_obj, *mask_obj, *angles_obj;
-  PyArrayObject *image_arr, *mask_arr, *angles_arr;
-  int Na;
+  int Ng, Ns, force2D, force2Ddimension;
+  PyObject *image_obj, *mask_obj;
+  PyArrayObject *image_arr, *mask_arr;
+  int n_a;
   int size[3];
   int strides[3];
   npy_intp dims[2];
-  PyArrayObject *glszm_arr;
+  PyArrayObject *glszm_arr, *angles_arr;
   int *image;
   char *mask;
+  int distances[1] = {1};
   int *angles;
   int *tempData;
   int maxRegion;
@@ -176,19 +221,28 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   int k;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOii", &image_obj, &mask_obj, &angles_obj, &Ng, &Ns))
+  if (!PyArg_ParseTuple(args, "OOiiii", &image_obj, &mask_obj, &Ng, &Ns, &force2D, &force2Ddimension))
     return NULL;
 
   // Interpret the input as numpy arrays
   image_arr = (PyArrayObject *)PyArray_FROM_OTF(image_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY |NPY_ARRAY_IN_ARRAY);
   mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_ARRAY_FORCECAST | NPY_ARRAY_ENSURECOPY | NPY_ARRAY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-4 if failed.
-  if(check_arrays(image_arr, mask_arr, angles_arr, size, strides) > 0) return NULL;
+  if(check_arrays(image_arr, mask_arr, size, strides) > 0) return NULL;
 
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
+  if(!force2D) force2Ddimension = -1;
+
+  // Generate the angles needed for texture matrix calculation
+  if (generate_angles(size, distances, 3, 1, 1, force2Ddimension, &angles, &n_a) > 0)  // 3D, dist 1, bi-directional
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting calculating angles.");
+    return NULL;
+  }
 
   // Initialize temporary output array (elements not set)
   // add +1 to the size so in the case every voxel represents a separate region,
@@ -198,7 +252,7 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   {
 	  Py_XDECREF(image_arr);
 	  Py_XDECREF(mask_arr);
-	  Py_XDECREF(angles_arr);
+	  free(angles);
 	  PyErr_SetString(PyExc_RuntimeError, "Failed to allocate memory for tempData");
 	  return NULL;
   }
@@ -206,17 +260,16 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
 
   //Calculate GLSZM
   maxRegion = 0;
-  maxRegion = calculate_glszm(image, mask, size, strides, angles, Na, tempData, Ng, Ns);
+  maxRegion = calculate_glszm(image, mask, size, strides, angles, n_a, tempData, Ng, Ns);
   if (maxRegion == -1) // Error occured
   {
 	  free(tempData);
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
+    free(angles);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of GLSZM Failed.");
     return NULL;
   }
@@ -224,7 +277,6 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   // Clean up image, mask and angles arrays (not needed anymore)
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
-  Py_XDECREF(angles_arr);
 
   // Initialize output array (elements not set)
   if (maxRegion == 0) maxRegion = 1;
@@ -232,13 +284,14 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   dims[1] = maxRegion;
   glszm_arr = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
   glszm = (double *)PyArray_DATA(glszm_arr);
-  
+
   // Set all elements to 0
-  for (k = Ng * maxRegion - 1; k >= 0; k--) glszm[k] = 0;
+  for (k = maxRegion * Ng - 1; k >= 0; k--) glszm[k] = 0;
 
   if (!fill_glszm(tempData, glszm, Ng, maxRegion))
   {
     free(tempData);
+    free(angles);
     Py_XDECREF(glszm_arr);
     PyErr_SetString(PyExc_RuntimeError, "Error filling GLSZM.");
     return NULL;
@@ -247,62 +300,79 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   // Clean up tempData
   free(tempData);
 
-  return PyArray_Return(glszm_arr);
+  // Wrap angles in a numpy array
+  dims[0] = n_a;
+  dims[1] = 3;
+  angles_arr = (PyArrayObject *)PyArray_SimpleNewFromData(2, dims, NPY_INT, angles);
+
+  // Ensure the Angles array owns the data, so it get's de-allocated when the array is dereferenced
+  PyArray_ENABLEFLAGS(angles_arr, NPY_ARRAY_OWNDATA);
+
+  return Py_BuildValue("OO", PyArray_Return(glszm_arr), PyArray_Return(angles_arr));
 }
 
 static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
 {
-  int Ng, Nr;
-  PyObject *image_obj, *mask_obj, *angles_obj;
-  PyArrayObject *image_arr, *mask_arr, *angles_arr;
-  int Na;
+  int Ng, Nr, force2D, force2Ddimension;
+  PyObject *image_obj, *mask_obj;
+  PyArrayObject *image_arr, *mask_arr;
+  int n_a;
   int size[3];
   int strides[3];
   npy_intp dims[3];
-  PyArrayObject *glrlm_arr;
+  PyArrayObject *glrlm_arr, *angles_arr;
   int *image;
   char *mask;
+  int distances[1] = {1};
   int *angles;
   double *glrlm;
   int k;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOii", &image_obj, &mask_obj, &angles_obj, &Ng, &Nr))
+  if (!PyArg_ParseTuple(args, "OOiiii", &image_obj, &mask_obj, &Ng, &Nr, &force2D, &force2Ddimension))
     return NULL;
 
   // Interpret the input as numpy arrays
   image_arr = (PyArrayObject *)PyArray_FROM_OTF(image_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
   mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BOOL, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-4 if failed.
-  if(check_arrays(image_arr, mask_arr, angles_arr, size, strides) > 0) return NULL;
+  if(check_arrays(image_arr, mask_arr, size, strides) > 0) return NULL;
 
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
+  if(!force2D) force2Ddimension = -1;
+
+  // Generate the angles needed for texture matrix calculation
+  if (generate_angles(size, distances, 3, 1, 0, force2Ddimension, &angles, &n_a) > 0)  // 3D, dist 1, mono-directional
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting calculating angles.");
+    return NULL;
+  }
 
   // Initialize output array (elements not set)
   dims[0] = Ng;
   dims[1] = Nr;
-  dims[2] = Na;
+  dims[2] = n_a;
   glrlm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
 
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
   glrlm = (double *)PyArray_DATA(glrlm_arr);
 
   // Set all elements to 0
-  for (k = Ng * Nr * Na - 1; k >= 0; k--) glrlm[k] = 0;
+  for (k = Ng * Nr * n_a - 1; k >= 0; k--) glrlm[k] = 0;
 
   //Calculate GLRLM
-  if (!calculate_glrlm(image, mask, size, strides, angles, Na, glrlm, Ng, Nr))
+  if (!calculate_glrlm(image, mask, size, strides, angles, n_a, glrlm, Ng, Nr))
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     Py_XDECREF(glrlm_arr);
+    free(angles);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of GLRLM Failed.");
     return NULL;
   }
@@ -310,41 +380,85 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
-  Py_XDECREF(angles_arr);
 
-  return PyArray_Return(glrlm_arr);
+  // Wrap angles in a numpy array
+  dims[0] = n_a;
+  dims[1] = 3;
+  angles_arr = (PyArrayObject *)PyArray_SimpleNewFromData(2, dims, NPY_INT, angles);
+
+  // Ensure the Angles array owns the data, so it get's de-allocated when the array is dereferenced
+  PyArray_ENABLEFLAGS(angles_arr, NPY_ARRAY_OWNDATA);
+
+  return Py_BuildValue("OO", PyArray_Return(glrlm_arr), PyArray_Return(angles_arr));
 }
 
 static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
 {
-  int Ng;
-  PyObject *image_obj, *mask_obj, *angles_obj;
-  PyArrayObject *image_arr, *mask_arr, *angles_arr;
-  int Na;
+  int Ng, force2D, force2Ddimension;
+  PyObject *image_obj, *mask_obj, *distances_obj;
+  PyArrayObject *image_arr, *mask_arr, *distances_arr;
+  int n_a, n_dist;
   int size[3];
   int strides[3];
   npy_intp dims[2];
-  PyArrayObject *ngtdm_arr;
+  PyArrayObject *ngtdm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *distances, *angles;
   double *ngtdm;
   int k;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOi", &image_obj, &mask_obj, &angles_obj, &Ng))
+  if (!PyArg_ParseTuple(args, "OOOiii", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension))
     return NULL;
 
   // Interpret the image and mask objects as numpy arrays
   image_arr = (PyArrayObject *)PyArray_FROM_OTF(image_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
   mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BOOL, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-4 if failed.
-  if(check_arrays(image_arr, mask_arr, angles_arr, size, strides) > 0) return NULL;
+  if(check_arrays(image_arr, mask_arr, size, strides) > 0) return NULL;
 
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  // Interpret the distance object as numpy array
+  distances_arr = (PyArrayObject *)PyArray_FROM_OTF(distances_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
+
+  if (distances_arr == NULL)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Error parsing distances array.");
+    return NULL;
+  }
+
+  if (PyArray_NDIM(distances_arr) != 1)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting distances array to be 1-dimensional.");
+    return NULL;
+  }
+
+  // Get the number of distances and the distances array data
+  n_dist = (int)PyArray_DIM(distances_arr, 0);
+  distances = (int *)PyArray_DATA(distances_arr);
+
+  // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
+  if(!force2D) force2Ddimension = -1;
+
+  // Generate the angles needed for texture matrix calculation
+  if (generate_angles(size, distances, 3, n_dist, 1, force2Ddimension, &angles, &n_a) > 0)  // 3D bi-directional
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting calculating angles.");
+    return NULL;
+  }
+
+  // Clean up distances array
+  Py_XDECREF(distances_arr);
 
   // Initialize output array (elements not set)
   dims[0] = Ng;
@@ -354,19 +468,18 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
   ngtdm = (double *)PyArray_DATA(ngtdm_arr);
 
   // Set all elements to 0
   for (k = Ng * 3 - 1; k >= 0; k--) ngtdm[k] = 0;
 
   //Calculate NGTDM
-  if (!calculate_ngtdm(image, mask, size, strides, angles, Na, ngtdm, Ng))
+  if (!calculate_ngtdm(image, mask, size, strides, angles, n_a, ngtdm, Ng))
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     Py_XDECREF(ngtdm_arr);
+    free(angles);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of NGTDM Failed.");
     return NULL;
   }
@@ -374,63 +487,106 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
-  Py_XDECREF(angles_arr);
 
-  return PyArray_Return(ngtdm_arr);
+  // Wrap angles in a numpy array
+  dims[0] = n_a;
+  dims[1] = 3;
+  angles_arr = (PyArrayObject *)PyArray_SimpleNewFromData(2, dims, NPY_INT, angles);
+
+  // Ensure the Angles array owns the data, so it get's de-allocated when the array is dereferenced
+  PyArray_ENABLEFLAGS(angles_arr, NPY_ARRAY_OWNDATA);
+
+  return Py_BuildValue("OO", PyArray_Return(ngtdm_arr), PyArray_Return(angles_arr));
 }
 
 static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
 {
-  int Ng, alpha;
-  PyObject *image_obj, *mask_obj, *angles_obj;
-  PyArrayObject *image_arr, *mask_arr, *angles_arr;
-  int Na;
+  int Ng, alpha, force2D, force2Ddimension;
+  PyObject *image_obj, *mask_obj, *distances_obj;
+  PyArrayObject *image_arr, *mask_arr, *distances_arr;
+  int n_a, n_dist;
   int size[3];
   int strides[3];
   npy_intp dims[2];
-  PyArrayObject *gldm_arr;
+  PyArrayObject *gldm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *distances, *angles;
   double *gldm;
   int k;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOii", &image_obj, &mask_obj, &angles_obj, &Ng, &alpha))
+  if (!PyArg_ParseTuple(args, "OOOiiii", &image_obj, &mask_obj, &distances_obj, &Ng, &alpha, &force2D, &force2Ddimension))
     return NULL;
 
   // Interpret the image and mask objects as numpy arrays
   image_arr = (PyArrayObject *)PyArray_FROM_OTF(image_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
   mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BOOL, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-4 if failed.
-  if(check_arrays(image_arr, mask_arr, angles_arr, size, strides) > 0) return NULL;
+  if(check_arrays(image_arr, mask_arr, size, strides) > 0) return NULL;
 
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  // Interpret the distance object as numpy array
+  distances_arr = (PyArrayObject *)PyArray_FROM_OTF(distances_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
+
+  if (distances_arr == NULL)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Error parsing distances array.");
+    return NULL;
+  }
+
+  if (PyArray_NDIM(distances_arr) != 1)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting distances array to be 1-dimensional.");
+    return NULL;
+  }
+
+  // Get the number of distances and the distances array data
+  n_dist = (int)PyArray_DIM(distances_arr, 0);
+  distances = (int *)PyArray_DATA(distances_arr);
+
+  // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
+  if(!force2D) force2Ddimension = -1;
+
+  // Generate the angles needed for texture matrix calculation
+  if (generate_angles(size, distances, 3, n_dist, 1, force2Ddimension, &angles, &n_a) > 0)  // 3D bi-directional
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(distances_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting calculating angles.");
+    return NULL;
+  }
+
+  // Clean up distances array
+  Py_XDECREF(distances_arr);
 
   // Initialize output array (elements not set)
   dims[0] = Ng;
-  dims[1] = Na * 2 + 1;  // No of possible dependency values = Na *2 + 1 (Na angels, 2 directions and +1 for no dependency)
+  dims[1] = n_a * 2 + 1;  // No of possible dependency values = Na *2 + 1 (Na angels, 2 directions and +1 for no dependency)
   gldm_arr = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
 
   // Get arrays in Ctype
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
   gldm = (double *)PyArray_DATA(gldm_arr);
 
   // Set all elements to 0
-  for (k = Ng * (Na * 2 + 1) - 1; k >= 0; k--) gldm[k] = 0;
+  for (k = Ng * (n_a * 2 + 1) - 1; k >= 0; k--) gldm[k] = 0;
 
   //Calculate GLDM
-  if (!calculate_gldm(image, mask, size, strides, angles, Na, gldm, Ng, alpha))
+  if (!calculate_gldm(image, mask, size, strides, angles, n_a, gldm, Ng, alpha))
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     Py_XDECREF(gldm_arr);
+    free(angles);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of GLDM Failed.");
     return NULL;
   }
@@ -438,29 +594,34 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
-  Py_XDECREF(angles_arr);
 
-  return PyArray_Return(gldm_arr);
+  // Wrap angles in a numpy array
+  dims[0] = n_a;
+  dims[1] = 3;
+  angles_arr = (PyArrayObject *)PyArray_SimpleNewFromData(2, dims, NPY_INT, angles);
+
+  // Ensure the Angles array owns the data, so it get's de-allocated when the array is dereferenced
+  PyArray_ENABLEFLAGS(angles_arr, NPY_ARRAY_OWNDATA);
+
+  return Py_BuildValue("OO", PyArray_Return(gldm_arr), PyArray_Return(angles_arr));
 }
 
-int check_arrays(PyArrayObject *image_arr, PyArrayObject *mask_arr, PyArrayObject *angles_arr, int *size, int *strides)
+int check_arrays(PyArrayObject *image_arr, PyArrayObject *mask_arr, int *size, int *strides)
 {
-  if (image_arr == NULL || mask_arr == NULL || angles_arr == NULL)
+  if (image_arr == NULL || mask_arr == NULL)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     PyErr_SetString(PyExc_RuntimeError, "Error parsing array arguments.");
     return 1;
   }
 
   // Check if Image and Mask have 3 dimensions, and if Angles has 2 dimensions
-  if (PyArray_NDIM(image_arr) != 3 || PyArray_NDIM(mask_arr) != 3 || PyArray_NDIM(angles_arr) != 2)
+  if (PyArray_NDIM(image_arr) != 3 || PyArray_NDIM(mask_arr) != 3)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
-    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for image and mask, 2D array for angles.");
+    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for image and mask.");
     return 2;
   }
 
@@ -478,19 +639,8 @@ int check_arrays(PyArrayObject *image_arr, PyArrayObject *mask_arr, PyArrayObjec
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
     PyErr_SetString(PyExc_RuntimeError, "Dimensions of image and mask do not match.");
     return 3;
-  }
-
-  // Check if second dimension of angles = 3 (1 for each dimension in image/mask
-  if ((int)PyArray_DIM(angles_arr, 1) != 3)
-  {
-    Py_XDECREF(image_arr);
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
-    PyErr_SetString(PyExc_RuntimeError, "Expecting angels to be of shape (Na, 3), but 2nd dimension is not size 3.");
-    return 4;
   }
 
   // Everything checked out!

--- a/radiomics/src/_cshape.c
+++ b/radiomics/src/_cshape.c
@@ -106,8 +106,8 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
   // Check if Image and Mask have 3 dimensions
   if (PyArray_NDIM(mask_arr) != 3)
   {
-    Py_DECREF(mask_arr);
-    Py_DECREF(spacing_arr);
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
     PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for mask.");
     return NULL;
   }
@@ -125,8 +125,8 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
   SA = calculate_surfacearea(mask, size, spacing);
 
   // Clean up
-  Py_DECREF(mask_arr);
-  Py_DECREF(spacing_arr);
+  Py_XDECREF(mask_arr);
+  Py_XDECREF(spacing_arr);
 
   if (SA < 0) // if SA < 0, an error has occurred
   {

--- a/radiomics/src/_cshape.c
+++ b/radiomics/src/_cshape.c
@@ -1,3 +1,5 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
 #include <stdlib.h>
 #include <Python.h>
 #include <numpy/arrayobject.h>
@@ -13,10 +15,12 @@ static char module_docstring[] = "This module links to C-compiled code for effic
 static char surface_docstring[] = "Arguments: Mask, PixelSpacing, uses a marching cubes algorithm to calculate an "
                                   "approximation to the total surface area. The isovalue is considered to be situated "
                                   "midway between a voxel that is part of the segmentation and a voxel that is not.";
-static char diameter_docstring[] = "Arguments: Mask, PixelSpacing, Angles, ROI size.";
+static char diameter_docstring[] = "Arguments: Mask, PixelSpacing, ROI size.";
 
 static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args);
 static PyObject *cshape_calculate_diameter(PyObject *self, PyObject *args);
+
+int check_arrays(PyArrayObject *mask_arr, PyArrayObject *spacing_arr, int *size, int *strides);
 
 static PyMethodDef module_methods[] = {
   //{"calculate_", cmatrices_, METH_VARARGS, _docstring},
@@ -84,6 +88,7 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
   PyObject *mask_obj, *spacing_obj;
   PyArrayObject *mask_arr, *spacing_arr;
   int size[3];
+  int strides[3];
   char *mask;
   double *spacing;
   double SA;
@@ -92,37 +97,17 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
     return NULL;
 
   // Interpret the input as numpy arrays
-  mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
-  spacing_arr = (PyArrayObject *)PyArray_FROM_OTF(spacing_obj, NPY_DOUBLE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
+  mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
+  spacing_arr = (PyArrayObject *)PyArray_FROM_OTF(spacing_obj, NPY_DOUBLE, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
-    // Check if there were any errors during casting to array objects
-  if (mask_arr == NULL || spacing_arr == NULL)
-  {
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(spacing_arr);
-    return NULL;
-  }
-
-  // Check if Image and Mask have 3 dimensions
-  if (PyArray_NDIM(mask_arr) != 3)
-  {
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(spacing_arr);
-    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for mask.");
-    return NULL;
-  }
-
-  // Get sizes of the arrays
-  size[2] = (int)PyArray_DIM(mask_arr, 2);
-  size[1] = (int)PyArray_DIM(mask_arr, 1);
-  size[0] = (int)PyArray_DIM(mask_arr, 0);
+  if (check_arrays(mask_arr, spacing_arr, size, strides) > 0) return NULL;
 
   // Get arrays in Ctype
   mask = (char *)PyArray_DATA(mask_arr);
   spacing = (double *)PyArray_DATA(spacing_arr);
 
   //Calculate Surface Area
-  SA = calculate_surfacearea(mask, size, spacing);
+  SA = calculate_surfacearea(mask, size, strides, spacing);
 
   // Clean up
   Py_XDECREF(mask_arr);
@@ -139,63 +124,38 @@ static PyObject *cshape_calculate_surfacearea(PyObject *self, PyObject *args)
 
 static PyObject *cshape_calculate_diameter(PyObject *self, PyObject *args)
 {
-  PyObject *mask_obj, *spacing_obj, *angles_obj;
-  PyArrayObject *mask_arr, *spacing_arr, *angles_arr;
-  int Ns, Na;
+  PyObject *mask_obj, *spacing_obj;
+  PyArrayObject *mask_arr, *spacing_arr;
+  int Ns;
   int size[3];
+  int strides[3];
   char *mask;
   double *spacing;
-  int *angles;
   double *diameters;
   PyObject *rslt;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOi", &mask_obj, &spacing_obj, &angles_obj, &Ns))
+  if (!PyArg_ParseTuple(args, "OOi", &mask_obj, &spacing_obj, &Ns))
     return NULL;
 
   // Interpret the input as numpy arrays
-  mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
-  spacing_arr = (PyArrayObject *)PyArray_FROM_OTF(spacing_obj, NPY_DOUBLE, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
-  angles_arr = (PyArrayObject *)PyArray_FROM_OTF(angles_obj, NPY_INT, NPY_FORCECAST | NPY_UPDATEIFCOPY | NPY_IN_ARRAY);
+  mask_arr = (PyArrayObject *)PyArray_FROM_OTF(mask_obj, NPY_BYTE, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
+  spacing_arr = (PyArrayObject *)PyArray_FROM_OTF(spacing_obj, NPY_DOUBLE, NPY_ARRAY_FORCECAST | NPY_ARRAY_UPDATEIFCOPY | NPY_ARRAY_IN_ARRAY);
 
-  if (mask_arr == NULL || spacing_arr == NULL || angles_arr == NULL)
-  {
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(spacing_arr);
-    Py_XDECREF(angles_arr);
-    return NULL;
-  }
-
-  if (PyArray_NDIM(mask_arr) != 3)
-  {
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(spacing_arr);
-    Py_XDECREF(angles_arr);
-    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for image and mask.");
-    return NULL;
-  }
-
-  // Get sizes of the arrays
-  size[2] = (int)PyArray_DIM(mask_arr, 2);
-  size[1] = (int)PyArray_DIM(mask_arr, 1);
-  size[0] = (int)PyArray_DIM(mask_arr, 0);
-
-  Na = (int)PyArray_DIM(angles_arr, 0);
+  if (check_arrays(mask_arr, spacing_arr, size, strides) > 0) return NULL;
 
   // Get arrays in Ctype
   mask = (char *)PyArray_DATA(mask_arr);
   spacing = (double *)PyArray_DATA(spacing_arr);
-  angles = (int *)PyArray_DATA(angles_arr);
 
   // Initialize output array (elements not set)
   diameters = (double *)calloc(4, sizeof(double));
 
   // Calculating Max 3D Diameter
-  if (!calculate_diameter(mask, size, spacing, angles, Na, Ns, diameters))
+  if (!calculate_diameter(mask, size, strides, spacing, Ns, diameters))
   {
     Py_XDECREF(mask_arr);
     Py_XDECREF(spacing_arr);
-    Py_XDECREF(angles_arr);
     free(diameters);
     PyErr_SetString(PyExc_RuntimeError, "Calculation of maximum 3D diameter failed.");
     return NULL;
@@ -206,8 +166,53 @@ static PyObject *cshape_calculate_diameter(PyObject *self, PyObject *args)
   // Clean up
   Py_XDECREF(mask_arr);
   Py_XDECREF(spacing_arr);
-  Py_XDECREF(angles_arr);
   free(diameters);
 
   return rslt;
+}
+
+int check_arrays(PyArrayObject *mask_arr, PyArrayObject *spacing_arr, int *size, int *strides)
+{
+  if (mask_arr == NULL || spacing_arr == NULL)
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Error parsing array arguments.");
+    return 1;
+  }
+
+  if (PyArray_NDIM(mask_arr) != 3 || PyArray_NDIM(spacing_arr) != 1)
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expected a 3D array for mask, 1D for spacing.");
+    return 2;
+  }
+
+  if ( !PyArray_IS_C_CONTIGUOUS(mask_arr) || !PyArray_IS_C_CONTIGUOUS(spacing_arr))
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting input arrays to be C-contiguous.");
+    return 3;
+  }
+
+  if (PyArray_DIM(spacing_arr, 0) != 3)
+  {
+    Py_XDECREF(mask_arr);
+    Py_XDECREF(spacing_arr);
+    PyErr_SetString(PyExc_RuntimeError, "Expecting spacing array to have shape (3,).");
+    return 4;
+  }
+
+  // Get sizes of the arrays
+  size[2] = (int)PyArray_DIM(mask_arr, 2);
+  size[1] = (int)PyArray_DIM(mask_arr, 1);
+  size[0] = (int)PyArray_DIM(mask_arr, 0);
+
+  strides[2] = (int)(PyArray_STRIDE(mask_arr, 2) / PyArray_ITEMSIZE(mask_arr));
+  strides[1] = (int)(PyArray_STRIDE(mask_arr, 1) / PyArray_ITEMSIZE(mask_arr));
+  strides[0] = (int)(PyArray_STRIDE(mask_arr, 0) / PyArray_ITEMSIZE(mask_arr));
+
+  return 0;
 }

--- a/radiomics/src/cmatrices.c
+++ b/radiomics/src/cmatrices.c
@@ -59,8 +59,7 @@ int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles
   int max_region_idx = Ns * 2;
 
   int gl, region;
-  int i = 0;
-  int d, a;
+  int i, a;
   int cur_idx, cur_x, cur_y, cur_z, j;
 
   regionStack = (int *)calloc(Ns, sizeof(int));
@@ -91,29 +90,26 @@ int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles
         cur_z = (cur_idx / strides[0]);
         cur_y = (cur_idx % strides[0]) / strides[1];
         cur_x = (cur_idx % strides[0]) % strides[1];
-        for (d = 1; d >= -1; d -= 2) // Iterate over both directions for each angle
+        for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
         {
-          for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
+          // Check whether the neighbour index is not out of range (i.e. part of the image)
+          if (cur_z + angles[a * 3] >= 0 && cur_z + angles[a * 3] < size[0] &&
+            cur_y + angles[a * 3 + 1] >= 0 && cur_y + angles[a * 3 + 1] < size[1] &&
+            cur_x + angles[a * 3 + 2] >= 0 && cur_x + angles[a * 3 + 2] < size[2])
           {
-            // Check whether the neighbour index is not out of range (i.e. part of the image)
-            if (cur_z + d * angles[a * 3] >= 0 && cur_z + d * angles[a * 3] < size[0] &&
-              cur_y + d * angles[a * 3 + 1] >= 0 && cur_y + d * angles[a * 3 + 1] < size[1] &&
-              cur_x + d * angles[a * 3 + 2] >= 0 && cur_x + d * angles[a * 3 + 2] < size[2])
+            j = cur_idx + angles[a * 3] * strides[0] +
+                          angles[a * 3 + 1] * strides[1] +
+                          angles[a * 3 + 2] * strides[2];
+            // Check whether neighbour voxel is part of the current region and unprocessed
+            if (mask[j] && (image[j] == gl))
             {
-              j = cur_idx + d * angles[a * 3] * strides[0] +
-                            d * angles[a * 3 + 1] * strides[1] +
-                            d * angles[a * 3 + 2] * strides[2];
-              // Check whether neighbour voxel is part of the current region and unprocessed
-              if (mask[j] && (image[j] == gl))
-              {
-                // Push the voxel index to the stack for further processing
-                regionStack[++stackTop] = j;
-                // Voxel belongs to current region, mark it as 'processed'
-                mask[j] = 0;
-              }
+              // Push the voxel index to the stack for further processing
+              regionStack[++stackTop] = j;
+              // Voxel belongs to current region, mark it as 'processed'
+              mask[j] = 0;
             }
-          } // next a
-        } // next d
+          }
+        } // next a
       }  // while (stackTop > -1)
 
       if (regionCounter >= max_region_idx)
@@ -398,7 +394,7 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles
   int iz, iy, ix;
   int offset[3];
   double count, sum, diff;
-  int d, a;
+  int a;
   int ngtdm_idx;
 
   // Fill gray levels (empty slices gray levels are later deleted in python)
@@ -419,27 +415,24 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles
         {
           count = 0;
           sum = 0;
-          for (d = 1; d >= -1; d-=2) // Iterate over both directions for each angle
+          for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
           {
-            for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
-            {
-              offset[0] = d * angles[a * 3];
-              offset[1] = d * angles[a * 3 + 1];
-              offset[2] = d * angles[a * 3 + 2];
+            offset[0] = angles[a * 3];
+            offset[1] = angles[a * 3 + 1];
+            offset[2] = angles[a * 3 + 2];
 
-              // Check whether the neighbour index is not out of range (i.e. part of the image)
-              if (iz + offset[0] >= 0 && iz + offset[0] < size[0] &&
-                  iy + offset[1] >= 0 && iy + offset[1] < size[1] &&
-                  ix + offset[2] >= 0 && ix + offset[2] < size[2])
+            // Check whether the neighbour index is not out of range (i.e. part of the image)
+            if (iz + offset[0] >= 0 && iz + offset[0] < size[0] &&
+                iy + offset[1] >= 0 && iy + offset[1] < size[1] &&
+                ix + offset[2] >= 0 && ix + offset[2] < size[2])
+            {
+              j = i + offset[0] * strides[0] +
+                      offset[1] * strides[1] +
+                      offset[2] * strides[2];
+              if (mask[j])  // Check whether neighbour voxel is part of the segmentation
               {
-                j = i + offset[0] * strides[0] +
-                        offset[1] * strides[1] +
-                        offset[2] * strides[2];
-                if (mask[j])  // Check whether neighbour voxel is part of the segmentation
-                {
-                 count++;
-                 sum += image[j];
-                }
+               count++;
+               sum += image[j];
               }
             }
           }
@@ -471,7 +464,7 @@ int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles,
   int i = 0, j = 0;
   int iz, iy, ix;
   int offset[3];
-  int dep, d, a, diff;
+  int dep, a, diff;
   int gldm_idx;
   for (iz = 0; iz < size[0]; iz ++) // Iterate over all voxels in a row - column - slice order
   {
@@ -482,28 +475,25 @@ int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles,
         if (mask[i])  // Check if the current voxel is part of the segmentation
         {
           dep = 0;
-          for (d = 1; d >= -1; d-=2) // Iterate over both directions for each angle d = {1, -1}
+          for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
           {
-            for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
-            {
-              offset[0] = d * angles[a * 3];
-              offset[1] = d * angles[a * 3 + 1];
-              offset[2] = d * angles[a * 3 + 2];
+            offset[0] = angles[a * 3];
+            offset[1] = angles[a * 3 + 1];
+            offset[2] = angles[a * 3 + 2];
 
-              // Check whether the neighbour index is not out of range (i.e. part of the image)
-              if (iz + offset[0] >= 0 && iz + offset[0] < size[0] &&
-                  iy + offset[1] >= 0 && iy + offset[1] < size[1] &&
-                  ix + offset[2] >= 0 && ix + offset[2] < size[2])
+            // Check whether the neighbour index is not out of range (i.e. part of the image)
+            if (iz + offset[0] >= 0 && iz + offset[0] < size[0] &&
+                iy + offset[1] >= 0 && iy + offset[1] < size[1] &&
+                ix + offset[2] >= 0 && ix + offset[2] < size[2])
+            {
+              j = i + offset[0] * strides[0] +
+                      offset[1] * strides[1] +
+                      offset[2] * strides[2];
+              if (mask[j])  // Check whether neighbour voxel is part of the segmentation
               {
-                j = i + offset[0] * strides[0] +
-                        offset[1] * strides[1] +
-                        offset[2] * strides[2];
-                if (mask[j])  // Check whether neighbour voxel is part of the segmentation
-                {
-                  diff = image[i] - image[j];
-                  if (diff < 0) diff *= -1;  // Get absolute difference
-                  if (diff <= alpha) dep++;
-                }
+                diff = image[i] - image[j];
+                if (diff < 0) diff *= -1;  // Get absolute difference
+                if (diff <= alpha) dep++;
               }
             }
           }
@@ -518,4 +508,114 @@ int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles,
     }
   }
   return 1;
+}
+
+int generate_angles(int *size, int *distances, int n_dim, int n_dist, char bidirectional, int force2Ddim, int **angles, int *n_a)
+{
+  int *offset_stride;
+  int max_distance, n_offsets, offset, a_dist;
+  int Na_d, Na_dd;  // Angles per distance
+  int dist_idx, dim_idx, a_idx, new_a_idx;
+
+  // First, determine the maximum distance and the number of angles to compute
+  // Number of angles to compute for distance Na_d = (2d + 1)^n_dim - (2d - 1)^n_dim
+  // The first term is temporarily stored in Na_d, the second in Na_dd
+  *n_a = 0;
+  max_distance = 0;  // Maximum offset specified, needed later on to generate the range of offsets
+  for (dist_idx = 0; dist_idx < n_dist; dist_idx++)
+  {
+    if (distances[dist_idx] < 1) return 1;  // invalid distance encountered
+
+    // Store maximum distance specified
+    if (max_distance < distances[dist_idx]) max_distance = distances[dist_idx];
+
+    Na_d = 1;
+    Na_dd = 1;
+    for (dim_idx = 0; dim_idx < n_dim; dim_idx++)
+    {
+        // Do not generate angles that move in the out-of-plane dimension
+        if (dim_idx == force2Ddim) continue;
+
+        // Check if the distance is within the image size for this dimension
+        if (distances[dist_idx] < size[dim_idx])
+        {
+          // Full range possible, in this dimension, so multiply by (2d + 1) and (2d -1)
+          Na_d *= (2 * distances[dist_idx] + 1);
+          Na_dd *= (2 * distances[dist_idx] - 1);
+        }
+        else
+        {
+          // Limited range possible, so multiply by (2 * (size - 1) + 1) (i.e. max possible distance for this size)
+          Na_d *= (2 *(size[dim_idx] - 1) + 1);
+          Na_dd *= (2 *(size[dim_idx] - 1) + 1);
+        }
+    }
+    *n_a += (Na_d - Na_dd);  // Add the number of angles to be generated for this distance to the grand total
+  }
+
+  // if only single direction is needed, divide Na by 2 (if bidirectional, Na will be even, and angles is a mirrored)
+  if (!bidirectional) (*n_a) /= 2;
+
+  // Initialize array to hold the angle offsets, shape (Na, n_dim), stored here as a flattened array
+  *angles = (int *)calloc(*n_a * n_dim, sizeof(int));
+
+  n_offsets = 2 * max_distance + 1;  // e.g. for max distance = 3, offsets = {-2, -1, 0, 1, 2}; ||offsets|| = 5
+
+  // offset_stride is used to generate the unique combinations of offsets for the angles
+  // For the last dimension the stride is 1, i.e. a different offset is used for each subsequent angle
+  // For the next-to-last dimension the stide is n_offsets, i.e. for each cycle through possible offsets in the last
+  // dimension, the offset in this dimension changes by 1.
+  // For subsequent dimensions, the stride is the previous stride multiplied by n_offsets, allowing the previous
+  // dimension to cycle through all possible offsets before advancing the offset in this dimension. e.g.:
+  // stride {9, 3, 1}. This reversed order ensures compatibility with Python generated angles
+  // angle   0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+  // dim 2  -1  0  1 -1  0  1 -1  0  1 -1  0  1 -1  0  1 -1  0  1 -1  0  1 -1  0  1 -1  0  1
+  // dim 1  -1 -1 -1  0  0  0  1  1  1 -1 -1 -1  0  0  0  1  1  1 -1 -1 -1  0  0  0  1  1  1
+  // dim 0  -1 -1 -1 -1 -1 -1 -1 -1 -1  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1
+  offset_stride = (int *)calloc(n_dim, sizeof(int));
+  offset_stride[n_dim - 1] = 1;
+  for (dim_idx = n_dim - 2; dim_idx >= 0; dim_idx--)
+  {
+    offset_stride[dim_idx] = offset_stride[dim_idx + 1] * n_offsets;
+  }
+
+  new_a_idx = 0;  // index used to generate new angle offset, increases during every loop
+  a_idx = 0;  // index in angles array of current angle being generated, increases only when a valid angle has been generated
+  while (a_idx < *n_a)
+  {
+    a_dist = 0;  // maximum offset of the angle, corresponds to the distance this angle belongs to (infinity norm)
+    // generate new angle
+    for (dim_idx = 0; dim_idx < n_dim; dim_idx++)
+    {
+      offset = max_distance - (new_a_idx / offset_stride[dim_idx]) % n_offsets;  // {max_d, ... , -max_d}, step 1
+      if ((dim_idx == force2Ddim && offset != 0) ||  // Moves in an invalid direction (out-of-plane dimension)
+          offset >= size[dim_idx] ||  // Offset (positive) larger than size
+          offset <= -size[dim_idx])   // Offset (negative) smaller than negative size
+      {
+        a_dist = -1;  // invalid angle
+        break;  // no need to generate offsets for other dimensions, angle is invalid
+      }
+      (*angles)[a_idx * n_dim + dim_idx] = offset;
+
+      if (a_dist < offset) a_dist = offset;  // offset positive
+      else if (a_dist < -offset) a_dist = -offset;  // offset negative
+    }
+
+    new_a_idx++;  // always advance new_a_idx, this controls the combination of offsets in generating the angle
+
+    // Check if the distance this angle is generated for is requested (i.e. present in distances)
+    // In case of an invalid angle, a_dist = -1, and therefore
+    if (a_dist < 1) continue; // Angle is invalid, i.e a_dist = -1 (failed check) or a_dist = 0 (angle (0, 0, 0))
+    for (dist_idx = 0; dist_idx < n_dist; dist_idx++)
+    {
+      if (a_dist == distances[dist_idx])
+      {
+        a_idx++; // Angle valid, store it and move to the next
+        break;  // No need to check the other distances
+      }
+    }
+  }
+  free(offset_stride);
+
+  return 0;
 }

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -5,3 +5,4 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
 int run_diagonal(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int glrlm_idx_max, int Nr, int *jd, int a);
 int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *ngtdm, int Ng);
 int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *gldm, int Ng, int alpha);
+int generate_angles(int *size, int *distances, int n_dim, int n_dist, char bidirectional, int force2Ddim, int **angles, int *n_a);

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,7 +1,7 @@
-int calculate_glcm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, double *glcm, int Ng);
-int calculate_glszm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, int *tempData, int Ng, int Ns);
+int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glcm, int Ng);
+int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int *tempData, int Ng, int Ns);
 int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
 int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int Ng, int Nr);
 int run_diagonal(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int glrlm_idx_max, int Nr, int *jd, int a);
-int calculate_ngtdm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, double *ngtdm, int Ng);
-int calculate_gldm(int *image, char *mask, int Sx, int Sy, int Sz, int *angles, int Na, double *gldm, int Ng, int alpha);
+int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *ngtdm, int Ng);
+int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *gldm, int Ng, int alpha);

--- a/radiomics/src/cshape.h
+++ b/radiomics/src/cshape.h
@@ -1,3 +1,2 @@
-double calculate_surfacearea(char *mask, int *size, double *spacing);
-void interpolate(double *vertEntry, int a1, int a2, double *spacing);
-int calculate_diameter(char *mask, int *size, double *spacing, int *angles, int Na, int Ns, double *diameters);
+double calculate_surfacearea(char *mask, int *size, int *strides, double *spacing);
+int calculate_diameter(char *mask, int *size, int *strides, double *spacing, int Ns, double *diameters);

--- a/tests/test_cmatrices.py
+++ b/tests/test_cmatrices.py
@@ -67,5 +67,10 @@ class TestFeatures:
       pyMat = featureClass._calculateMatrix()
       assert pyMat is not None
 
+      if len(pyMat.shape) == 3:
+        # specific matrices per angle, so ensure angles are in the same order for python and C calculated matrices
+        pyMat = numpy.array([pyMat[:, :, x] for x in (12, 11, 10, 8, 7, 6, 4, 3, 2, 9, 5, 1, 0)])
+        pyMat = pyMat.transpose((1, 2, 0))
+
       # Check if the calculated arrays match
       assert numpy.max(numpy.abs(pyMat - cMat)) < 1e-3


### PR DESCRIPTION
Various changes to the C extension with the aim of consistency between functions and the new implementation of C-generated angles.

- Move common functionality to different function (mainly various checks to ensure valid input data is provided)
- Make the texture functions more similar where possible (mainly use of `strides` and `size` arrays)
- Simplify surface area (removes a lot of unnecessary calculations)
- Remove deprecated numpy functionality and define constant to enforce no use of deprecated functionality in the future
- implement C function to generate angles and call this from the texture functions. Because sometimes the angles are used later on (e.g. matrix weighting), generated angles are also included in the return value; a tuple of `(matrix, angles)` is returned.

The implementation of C-generated angles does not lead to a marked increase in performance in normal mode, but it does contribute when PyRadiomics is operated in voxel-based calculation (see #337). This is due to the fact that the number of times angles are generated is then increased by N_voxels.

cc @Radiomics/developers 
