### PR TITLE
ENH: Add support for using a fixed bin count

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -277,6 +277,9 @@ Feature Class Level
 *Image discretization*
 
 - ``binWidth`` [25]: Float, > 0, size of the bins when making a histogram and for discretization of the image gray level.
+- ``binCount`` [None]: integer, > 0, specifies the number of bins to create. The width of the bin is
+  then determined by the range in the ROI. No definitive evidence is available on which method of discretization is
+  superior, we advise a fixed bin width. See more :ref:`here <radiomics_fixed_bin_width>`.
 
 *Forced 2D extraction*
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -114,6 +114,37 @@ Interactive Use
 
 * See the :ref:`feature extractor class<radiomics-featureextractor-label>` for more information on using this core class.
 
+----------------------
+Voxel-based extraction
+----------------------
+
+As of version 2.0, pyradiomics also implements a voxel-based extraction.
+Currently, this is only available in the interactive mode, and is as simple as telling the feature extractor to
+extract a parameter map::
+
+    from radiomics import featureextractor, getTestCase
+    import six
+    import sys, os
+
+    import SimpleITK as sitk
+
+    dataDir = '/path/to/pyradiomics'
+
+    imageName, maskName = getTestCase('brain1', dataDir)
+    params = os.path.join(dataDir, "examples", "exampleSettings", "exampleVoxel.yaml")
+
+    extractor = featureextractor.RadiomicsFeaturesExtractor(params)
+
+    result = extractor.execute(imageName, maskName, voxelBased=True)
+
+    for key, val in six.iteritems(result):
+      sitk.WriteImage(val, key + 'nrrd')
+
+Important to know here is that this extraction takes longer (features have to be calculated for each voxel), and that
+the output is a SimpleITK image of the parameter map in stead of a float value *for each feature*.
+
+Be sure to also check out the ``helloVoxel.py`` example available in the repository (folder ``examples``).
+
 ------------------------
 PyRadiomics in 3D Slicer
 ------------------------
@@ -126,7 +157,7 @@ Using feature classes directly
 ------------------------------
 
 * This represents an example where feature classes are used directly, circumventing checks and preprocessing done by
-  the radiomics feature extractor class, and is not intended as standard use example.
+  the radiomics feature extractor class, and is not intended as standard use.
 
 * (LINUX) To run from source code, add pyradiomics to the environment variable PYTHONPATH (Not necessary when
   PyRadiomics is installed):
@@ -196,4 +227,4 @@ handler to the pyradiomics logger::
 
 To store a log file when running pyradiomics from the commandline, specify a file location in the optional
 ``--log-file`` argument. The amount of logging that is stored is controlled by the ``--log-level`` argument
-(default level INFO and up).
+(default level WARNING and up).

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -66,6 +66,9 @@ class RadiomicsFeaturesBase(object):
     self.settings = kwargs
 
     self.binWidth = kwargs.get('binWidth', 25)
+    # Although binCount is available, we advise use of binWidth!
+    # See documentation/FAQ/Input-Customization for more details.
+    self.binCount = kwargs.get('binCount', None)
     self.label = kwargs.get('label', 1)
     self.voxelBased = kwargs.get('voxelBased', False)
     self.initValue = kwargs.get('initValue', 0)
@@ -176,7 +179,8 @@ class RadiomicsFeaturesBase(object):
   def _applyBinning(self):
     self.matrix, self.binEdges = imageoperations.binImage(self.binWidth,
                                                           self.imageArray,
-                                                          self.maskArray)
+                                                          self.maskArray,
+                                                          self.settings.get('binCount', None))
     self.coefficients['grayLevels'] = numpy.unique(self.matrix[self.maskArray])
     self.coefficients['Ng'] = int(numpy.max(self.coefficients['grayLevels']))  # max gray level in the ROI
 

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -368,6 +368,11 @@ class RadiomicsFeaturesExtractor:
     self.logger.debug('Enabled features: %s', self._enabledFeatures)
     self.logger.debug('Current settings: %s', self.settings)
 
+    if self.settings.get('binCount', None) is not None:
+      self.logger.warning('Fixed bin Count enabled! However, we recommend using a fixed bin Width. See '
+                          'http://pyradiomics.readthedocs.io/en/latest/faq.html#radiomics-fixed-bin-width for more '
+                          'details')
+
     # 1. Load the image and mask
     featureVector = collections.OrderedDict()
     image, mask = self.loadImage(imageFilepath, maskFilepath)

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -52,7 +52,7 @@ def getBinEdges(binwidth, parameterValues):
   return binEdges  # numpy.histogram(parameterValues, bins=binedges)
 
 
-def binImage(binwidth, parameterMatrix, parameterMatrixCoordinates=None):
+def binImage(binwidth, parameterMatrix, parameterMatrixCoordinates=None, bincount=None):
   r"""
   Discretizes the parameterMatrix (matrix representation of the gray levels in the ROI) using the binEdges calculated
   using :py:func:`getBinEdges`. Only voxels defined by parameterMatrixCoordinates (defining the segmentation) are used
@@ -84,10 +84,16 @@ def binImage(binwidth, parameterMatrix, parameterMatrixCoordinates=None):
   logger.debug('Discretizing gray levels inside ROI')
 
   if parameterMatrixCoordinates is None:
-    binEdges = getBinEdges(binwidth, parameterMatrix[:])
+    if bincount is not None:
+      binEdges = numpy.histogram(parameterMatrix[:], bincount)[1]
+    else:
+      binEdges = getBinEdges(binwidth, parameterMatrix[:])
     parameterMatrix = numpy.digitize(parameterMatrix, binEdges)
   else:
-    binEdges = getBinEdges(binwidth, parameterMatrix[parameterMatrixCoordinates])
+    if bincount is not None:
+      binEdges = numpy.histogram(parameterMatrix[parameterMatrixCoordinates], bincount)
+    else:
+      binEdges = getBinEdges(binwidth, parameterMatrix[parameterMatrixCoordinates])
     parameterMatrix[parameterMatrixCoordinates] = numpy.digitize(parameterMatrix[parameterMatrixCoordinates], binEdges)
 
   return parameterMatrix, binEdges

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -29,6 +29,10 @@ mapping:
         type: float
         range:
           min-ex: 0
+      binCount:
+        type: int
+        range:
+          min-ex: 0
       normalize:
         type: bool
       normalizeScale:


### PR DESCRIPTION
For extra compatibility allow user to extract using a fixed bincount. 
Include a warning when fixed bincount is used to show the recommendation for a fixed bin width.

See [this FAQ topic](http://pyradiomics.readthedocs.io/en/latest/faq.html#why-is-there-no-parameter-to-specify-a-fixed-bin-count) for more details.