### PR TITLE
BUG: Fix missing packages in Dockerfile

### DIFF
--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -93,6 +93,9 @@ RUN git clone https://github.com/radiomics/pyradiomics.git && \
   python get-pip.py && \
   pip install wheel>=0.29.0 && \
   pip install setuptools>=28.0.0 && \
+  pip install scipy && \
+  pip install trimesh && \
+  pip install scikit-image && \
   pip install --trusted-host www.itk.org -f https://itk.org/SimpleITKDoxygen/html/PyDownloadPage.html SimpleITK>=0.9.1 && \
   python -c "import SimpleITK; print('SimpleITK Version:' + SimpleITK.Version_VersionString())" && \
   pip install -r requirements.txt && \

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -896,7 +896,7 @@ def getLBP2DImage(inputImage, inputMask, **kwargs):
   .. note::
     LBP can often return only a very small number of different gray levels. A customized bin width is often needed.
   .. warning::
-    Requires package ``skimage`` to function. If not available, this filter logs a warning and does not yield an image.
+    Requires package ``scikit-image`` to function. If not available, this filter logs a warning and does not yield an image.
 
   References:
 


### PR DESCRIPTION
To enable local binary pattern 2D and 3D, scipy, scikit-image and trimesh are additionally required, but these are not mentioned in the requirements (to allow installing without these packages).

To enable these filters in the CLI-docker, add pip install lines for these packages to the dockerfile.