### PR TITLE
ENH: fix the assigment of x and y pixel spacing

### DIFF
--- a/radiomics/shape.py
+++ b/radiomics/shape.py
@@ -50,7 +50,7 @@ class RadiomicsShape(base.RadiomicsFeaturesBase):
 
     # Volume, Surface Area and eigenvalues are pre-calculated
     # Compute volume
-    z, x, y = self.pixelSpacing
+    z, y, x = self.pixelSpacing
     Np = len(self.labelledVoxelCoordinates[0])
     self.Volume = Np * (z * x * y)
 


### PR DESCRIPTION
Note that this issue has no effect on the calculation, but might be confusing to the developers,
and also might cause problems later in case those are reused in a feature where order matters.

Resolves #403