### PR TITLE
Fix memory leak in C extensions

### DIFF
--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -79,13 +79,13 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     self.logger.debug('Feature class initialized, calculated GLDM with shape %s', self.P_gldm.shape)
 
   def _calculateMatrix(self):
-    P_gldm, angles = cMatrices.calculate_gldm(self.matrix,
-                                              self.maskArray,
-                                              numpy.array(self.settings.get('distances', [1])),
-                                              self.coefficients['Ng'],
-                                              self.gldm_a,
-                                              self.settings.get('force2D', False),
-                                              self.settings.get('force2Ddimension', 0))
+    P_gldm = cMatrices.calculate_gldm(self.matrix,
+                                      self.maskArray,
+                                      numpy.array(self.settings.get('distances', [1])),
+                                      self.coefficients['Ng'],
+                                      self.gldm_a,
+                                      self.settings.get('force2D', False),
+                                      self.settings.get('force2Ddimension', 0))
 
     jvector = numpy.arange(1, P_gldm.shape[1] + 1, dtype='float64')
 

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -81,12 +81,12 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     Ng = self.coefficients['Ng']
     Ns = self.coefficients['Np']
 
-    P_glszm, angles = cMatrices.calculate_glszm(self.matrix,
-                                                self.maskArray,
-                                                Ng,
-                                                Ns,
-                                                self.settings.get('force2D', False),
-                                                self.settings.get('force2Ddimension', 0))
+    P_glszm = cMatrices.calculate_glszm(self.matrix,
+                                        self.maskArray,
+                                        Ng,
+                                        Ns,
+                                        self.settings.get('force2D', False),
+                                        self.settings.get('force2Ddimension', 0))
 
     # Delete rows that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values

--- a/radiomics/ngtdm.py
+++ b/radiomics/ngtdm.py
@@ -95,12 +95,12 @@ class RadiomicsNGTDM(base.RadiomicsFeaturesBase):
     self._calculateCoefficients()
 
   def _calculateMatrix(self):
-    P_ngtdm, angles = cMatrices.calculate_ngtdm(self.matrix,
-                                                self.maskArray,
-                                                numpy.array(self.settings.get('distances', [1])),
-                                                self.coefficients['Ng'],
-                                                self.settings.get('force2D', False),
-                                                self.settings.get('force2Ddimension', 0))
+    P_ngtdm = cMatrices.calculate_ngtdm(self.matrix,
+                                        self.maskArray,
+                                        numpy.array(self.settings.get('distances', [1])),
+                                        self.coefficients['Ng'],
+                                        self.settings.get('force2D', False),
+                                        self.settings.get('force2Ddimension', 0))
 
     # Delete empty grey levels
     P_ngtdm = numpy.delete(P_ngtdm, numpy.where(P_ngtdm[:, 0] == 0), 0)

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -5,4 +5,5 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
 int run_diagonal(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *glrlm, int glrlm_idx_max, int Nr, int *jd, int a);
 int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *ngtdm, int Ng);
 int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles, int Na, double *gldm, int Ng, int alpha);
-int generate_angles(int *size, int *distances, int n_dim, int n_dist, char bidirectional, int force2Ddim, int **angles, int *n_a);
+int get_angle_count(int *size, int *distances, int n_dim, int n_dist, char bidirectional, int force2Ddim);
+int build_angles(int *size, int *distances, int n_dim, int n_dist, int force2Ddim, int n_a, int *angles);


### PR DESCRIPTION
Since C functionality is implemented for the calculation of the angles, texture matrix calculation returns a tuple of the matrix and the angles.
However, this uses Py_BuildValue with specifier "O", which increases the reference count, and thereby introduces a memory leak.

Fix this by replacing "O" by "N", which has the same effect for the returned values, but does not increase the reference count.

Moreover, the angles array is only needed for GLCM and GLRLM matrices. Therefore, only return the angles array in these 2 functions and free the array in the other functions.

fixes #417.

cc @Radiomics/developers, @JianJuly