### PR TITLE
Extend resegmenting functionality

### DIFF
--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -419,7 +419,9 @@ class RadiomicsFeaturesExtractor:
     # 5. Resegment the mask if enabled (parameter regsegmentMask is not None)
     resegmentRange = self.settings.get('resegmentRange', None)
     if resegmentRange is not None:
-      resegmentedMask = imageoperations.resegmentMask(image, mask, resegmentRange, self.settings['label'])
+      resegmentMode = self.settings.get('resegmentMode', 'absolute')
+      resegmentedMask = imageoperations.resegmentMask(image, mask, resegmentRange, resegmentMode,
+                                                      self.settings['label'])
 
       # Recheck to see if the mask is still valid
       boundingBox, correctedMask = imageoperations.checkMask(image, resegmentedMask, **self.settings)

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -70,6 +70,9 @@ mapping:
       resegmentRange:
         seq:
           - type: float
+      resegmentMode:
+        type: str
+        enum: ['absolute', 'relative', 'sigma']
       preCrop:
         type: bool
       sigma:


### PR DESCRIPTION
In addition to the original mode (now default mode "absolute"), add new modes "relative" and "sigma", which allow for a dynamic threshold defined as either a threshold relative to the maximum value found in the ROI ("relative") or as a n * sigma difference from the mean ("sigma").

Additionally, it is now allowed to provide either 1 or 2 thresholds, where in case of 1 threshold it is interpreted as the lower threshold (i.e. retaining everything equal to or higher than that threshold).

In case the function fails, a ValueError is raised. The checks to determine the validity of the resegmented mask is not determined in this function, but is applied in the pipeline defined by featureextractor.