### PR TITLE
Thread safe logging

### DIFF
--- a/radiomics/scripts/__init__.py
+++ b/radiomics/scripts/__init__.py
@@ -2,9 +2,9 @@
 import argparse
 import csv
 from functools import partial
-import logging.handlers
 import logging.config
-from multiprocessing import cpu_count, Pool, Manager
+import logging.handlers
+from multiprocessing import cpu_count, Manager, Pool
 import os
 import sys
 import threading

--- a/radiomics/scripts/__init__.py
+++ b/radiomics/scripts/__init__.py
@@ -109,6 +109,8 @@ def parse_args(custom_arguments=None):
         scriptlogger.info('Finished extraction successfully...')
     else:
       return 1  # Feature extraction error
+  except (KeyboardInterrupt, SystemExit):
+    raise
   except Exception:
     scriptlogger.error('Error extracting features!', exc_info=True)
     return 3  # Unknown error
@@ -199,6 +201,8 @@ def _validateCases(case_generator, case_count, num_workers):
         c = pykwalify.core.Core(source_file=param, schema_files=[schemaFile], extensions=[schemaFuncs])
         try:
           c.validate()
+        except (KeyboardInterrupt, SystemExit):
+          raise
         except Exception as e:
           scriptlogger.error('Parameter validation failed!\n%s' % e.message)
     scriptlogger.debug("Validating case (%i/%i): %s", case_idx, case_count, case)
@@ -289,6 +293,8 @@ def _parseOverrides(overrides):
         setting_overrides[setting_key] = parse_value(setting_value, setting_type)
         scriptlogger.debug('Parsed "%s" as type "%s"; value: %s', setting_key, setting_type, setting_overrides[setting_key])
 
+    except (KeyboardInterrupt, SystemExit):
+      raise
     except Exception:
       scriptlogger.warning('Could not parse value "%s" for setting "%s", skipping...', setting_value, setting_key)
 

--- a/radiomics/scripts/segment.py
+++ b/radiomics/scripts/segment.py
@@ -42,6 +42,8 @@ def extractSegment(case_idx, case, config, config_override):
     delta_t = datetime.now() - t
     caseLogger.info('Patient %s processed in %s', case_idx, delta_t)
 
+  except (KeyboardInterrupt, SystemExit):
+    raise
   except Exception:
     caseLogger.error('Feature extraction failed!', exc_info=True)
 


### PR DESCRIPTION
Implement thread-safe logging to a file by using a `QueueHandler` and `QueueListener` to process the log records intended for the logfile. This ensures only 1 thread is writing to the file, preventing corruption in case of collisions.

Additionally, improve the error catching code in the commandline script to allow for cancellation by the user (via `KeyboardInterrupt`/ `SystemExit` and in case of parallel processing; by calling `pool.terminate()`)

cc @Radiomics/developers 