### PR TITLE
Add support for overlapping masks / Slicer Segementation objects

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -62,14 +62,16 @@ Command Line Use
   represents one combination of an image and a segmentation and contains at least 2 elements: 1) path/to/image,
   2) path/to/mask. The headers specify the column names and **must** be "Image" and "Mask" for image and mask location,
   respectively (capital sensitive). Additional columns may also be specified, all columns are copied to the output in
-  the same order (with calculated features appended after last column). To specify custom label values for each
+  the same order (with calculated features appended after last column). To specify custom values for ``label`` in each
   combination, a column "Label" can optionally be added, which specifies the desired extraction label for each
   combination. Values specified in this column take precedence over label values specified in the parameter file or on
-  the commandline. If a row contains no value, the default (or globally customized) value is used instead.
+  the commandline. If a row contains no value, the default (or globally customized) value is used instead. Similarly,
+  an optional value for the ``label_channel`` setting can be provided in a column "Label_channel".
 
   .. note::
 
     All headers should be unique and different from headers provided by PyRadiomics (``<filter>_<class>_<feature>``).
+    In case of conflict, values are overwritten by the PyRadiomics values.
 
 * By default, results are printed out to the console window. To store the results in a CSV-structured text file, add the
   ``-o <PATH>`` and ``-f csv`` arguments, where ``<PATH>`` specifies the filepath where the results should be stored.

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -333,7 +333,7 @@ class RadiomicsFeaturesExtractor:
     self._enabledFeatures.update(enabledFeatures)
     self.logger.debug('Enabled features: %s', self._enabledFeatures)
 
-  def execute(self, imageFilepath, maskFilepath, label=None, voxelBased=False):
+  def execute(self, imageFilepath, maskFilepath, label=None, label_channel=None, voxelBased=False):
     """
     Compute radiomics signature for provide image and mask combination. It comprises of the following steps:
 
@@ -355,7 +355,13 @@ class RadiomicsFeaturesExtractor:
     :param maskFilepath: SimpleITK Image, or string pointing to labelmap file location
     :param label: Integer, value of the label for which to extract features. If not specified, last specified label
         is used. Default label is 1.
+    :param label_channel: Integer, index of the channel to use when maskFilepath yields a SimpleITK.Image with a vector
+        pixel type. Default index is 0.
+    :param voxelBased: Boolean, default False. If set to true, a voxel-based extraction is performed, segment-based
+        otherwise.
     :returns: dictionary containing calculated signature ("<imageType>_<featureClass>_<featureName>":value).
+        In case of segment-based extraction, value type for features is float, if voxel-based, type is SimpleITK.Image.
+        Type of diagnostic features differs, but can always be represented as a string.
     """
     geometryTolerance = self.settings.get('geometryTolerance')
     additionalInfo = self.settings.get('additionalInfo', False)
@@ -365,6 +371,9 @@ class RadiomicsFeaturesExtractor:
       self.settings['label'] = label
     else:
       label = self.settings.get('label', 1)
+
+    if label_channel is not None:
+      self.settings['label_channel'] = label_channel
 
     if self.geometryTolerance != geometryTolerance:
       self._setTolerance()

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -505,11 +505,14 @@ class RadiomicsFeaturesExtractor:
       raise ValueError('Error reading image Filepath or SimpleITK object')
 
     if isinstance(MaskFilePath, six.string_types) and os.path.isfile(MaskFilePath):
-      mask = sitk.ReadImage(MaskFilePath, sitk.sitkUInt32)
+      mask = sitk.ReadImage(MaskFilePath)
     elif isinstance(MaskFilePath, sitk.SimpleITK.Image):
-      mask = sitk.Cast(MaskFilePath, sitk.sitkUInt32)
+      mask = MaskFilePath
     else:
       raise ValueError('Error reading mask Filepath or SimpleITK object')
+
+    # process the mask
+    mask = imageoperations.getMask(mask, **self.settings)
 
     if self.generalInfo is not None:
       self.generalInfo.addImageElements(image)

--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -13,36 +13,42 @@ logger = logging.getLogger(__name__)
 
 def getMask(mask, **kwargs):
   """
-  Function to get the correct mask. Includes enforcing a correct pixel data type.
+  Function to get the correct mask. Includes enforcing a correct pixel data type (UInt32).
 
   Also supports extracting the mask for a segmentation (stored as SimpleITK Vector image) if necessary.
-  In this case, the mask at index ``label - 1`` is extracted. All non-zero pixels in that mask are then set to the
-  value of the label.
+  In this case, the mask at index ``label_channel`` is extracted. The resulting 3D volume is then treated as it were a
+  scalar input volume (i.e. with the region of interest defined by voxels with value matching ``label``).
+
+  Finally, checks if the mask volume contains an ROI identified by ``label``. Raises a value error if the label is not
+  present (including a list of valid labels found).
 
   :param mask: SimpleITK Image object representing the mask. Can be a vector image to allow for overlapping masks.
-  :param kwargs: keyword arguments. If argument ``label`` is present, this is used to select the label. Otherwise
-    label ``1`` is assumed.
-  :return: 3D mask with pixel type UInt32
+  :param kwargs: keyword arguments. If argument ``label_channel`` is present, this is used to select the channel.
+    Otherwise label_channel ``0`` is assumed.
+  :return: SimpleITK.Image with pixel type UInt32 representing the mask volume
   """
   global logger
   label = kwargs.get('label', 1)
+  label_channel = kwargs.get('label_channel', 0)
   if 'vector' in mask.GetPixelIDTypeAsString().lower():
     logger.debug('Mask appears to be a segmentation object (=stored as vector image).')
     n_components = mask.GetNumberOfComponentsPerPixel()
-    assert label <= n_components, \
-        "Mask %i requested, but segmentation object only contains %i objects" % (label, n_components)
+    assert label_channel < n_components, \
+        "Mask %i requested, but segmentation object only contains %i objects" % (label_channel, n_components)
 
-    logger.debug('Extracting mask at index %i', label - 1)
+    logger.info('Extracting mask at index %i', label_channel)
     selector = sitk.VectorIndexSelectionCastImageFilter()
-    selector.SetIndex(label - 1)
+    selector.SetIndex(label_channel)
     mask = selector.Execute(mask)
 
-    logger.debug('Setting all non-zero elements in extracted mask to label value %i', label)
-    mask = sitk.Cast(mask != 0, sitk.sitkUInt32)  # Set all non-zero elements to 1, cast to UInt32
-    mask *= label  # Set all labelled voxels to the correct label
-  else:
-    logger.debug('Force casting mask to UInt32 to ensure correct datatype.')
-    mask = sitk.Cast(mask, sitk.sitkUInt32)
+  logger.debug('Force casting mask to UInt32 to ensure correct datatype.')
+  mask = sitk.Cast(mask, sitk.sitkUInt32)
+
+  labels = numpy.unique(sitk.GetArrayFromImage(mask))
+  if len(labels) == 0:
+    raise ValueError('No labels found in this mask (i.e. nothing is segmented)!', label, labels[labels != 0])
+  if label not in labels:
+    raise ValueError('Label (%g) not present in mask. Choose from %s', label, labels[labels != 0])
 
   return mask
 

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -25,6 +25,12 @@ mapping:
         type: bool
       label:
         type: int
+        range:
+          min-ex: 0
+      label_channel:
+        type: int
+        range:
+          min-ex: 0
       binWidth:
         type: float
         range:

--- a/radiomics/scripts/segment.py
+++ b/radiomics/scripts/segment.py
@@ -60,12 +60,15 @@ def _extractFeatures(case_idx, case, config, config_override):
     label = case.get('Label', None)  # Optional
     if isinstance(label, six.string_types):
       label = int(label)
+    label_channel = case.get('Label_channel', None)  # Optional
+    if isinstance(label_channel, six.string_types):
+      label_channel = int(label)
 
     # Instantiate Radiomics Feature extractor
     extractor = radiomics.featureextractor.RadiomicsFeaturesExtractor(config, **config_override)
 
     # Extract features
-    feature_vector.update(extractor.execute(imageFilepath, maskFilepath, label))
+    feature_vector.update(extractor.execute(imageFilepath, maskFilepath, label, label_channel))
 
     # Display message
     delta_t = datetime.now() - t

--- a/radiomics/scripts/voxel.py
+++ b/radiomics/scripts/voxel.py
@@ -34,12 +34,15 @@ def extractVoxel(case_idx, case, config, config_override, out_dir):
     label = case.get('Label', None)  # Optional
     if isinstance(label, six.string_types):
       label = int(label)
+    label_channel = case.get('Label_channel', None)  # Optional
+    if isinstance(label_channel, six.string_types):
+      label_channel = int(label)
 
     # Instantiate Radiomics Feature extractor
     extractor = radiomics.featureextractor.RadiomicsFeaturesExtractor(config, **config_override)
 
     # Extract features
-    result = extractor.execute(imageFilepath, maskFilepath, label, voxelBased=True)
+    result = extractor.execute(imageFilepath, maskFilepath, label, label_channel, voxelBased=True)
 
     for k in result:
       if isinstance(result[k], sitk.Image):


### PR DESCRIPTION
In the new version of Slicer, segmentation is done using Segmentation Objects, which allow for overlapping segmentation. When stored, these `.seg.nrrd` files can be read by SimpleITK as vector images. By extracting the nth index from the vector, a labelmap (3D volume) can be obtained representing the nth segement. To ensure correct functionality in the rest of PyRadiomics, all non-zero in the obtained mask are then set to the label value.