### PR TITLE
Add bounding box iteration

### DIFF
--- a/examples/exampleSettings/exampleVoxel.yaml
+++ b/examples/exampleSettings/exampleVoxel.yaml
@@ -15,3 +15,4 @@ voxelSetting:
   kernelRadius: 2
   maskedKernel: true
   initValue: nan
+  voxelBatch: 10000

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -274,7 +274,7 @@ class RadiomicsFeaturesBase(object):
     # Get the feature values using the current segment.
     for success, featureName, featureValue in self._calculateFeatures():
       # Always store the result. In case of an error, featureValue will be NaN
-      self.featureValues[featureName] = featureValue
+      self.featureValues[featureName] = numpy.squeeze(featureValue)
 
   def _calculateFeatures(self):
     # Initialize the calculation

--- a/radiomics/featureextractor.py
+++ b/radiomics/featureextractor.py
@@ -378,7 +378,10 @@ class RadiomicsFeaturesExtractor:
 
     if voxelBased:
       self.settings['voxelBased'] = True
+      kernelRadius = self.settings.get('kernelRadius', 1)
       self.logger.info('Starting voxel based extraction')
+    else:
+      kernelRadius = 0
 
     self.logger.info('Calculating features with label: %d', label)
     self.logger.debug('Enabled images types: %s', self._enabledImagetypes)
@@ -470,7 +473,7 @@ class RadiomicsFeaturesExtractor:
     # Calculate features for all (filtered) images in the generator
     for inputImage, imageTypeName, inputKwargs in imageGenerators:
       self.logger.info('Calculating features for %s image', imageTypeName)
-      inputImage, inputMask = imageoperations.cropToTumorMask(inputImage, mask, boundingBox)
+      inputImage, inputMask = imageoperations.cropToTumorMask(inputImage, mask, boundingBox, padDistance=kernelRadius)
       featureVector.update(self.computeFeatures(inputImage, inputMask, imageTypeName, **inputKwargs))
 
     self.logger.debug('Features extracted')

--- a/radiomics/firstorder.py
+++ b/radiomics/firstorder.py
@@ -1,6 +1,8 @@
 import numpy
+import SimpleITK as sitk
+from six.moves import range
 
-from radiomics import base, deprecated, imageoperations
+from radiomics import base, cMatrices, deprecated
 
 
 class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
@@ -33,33 +35,82 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
     self.pixelSpacing = inputImage.GetSpacing()
     self.voxelArrayShift = kwargs.get('voxelArrayShift', 0)
+    self.discretizedImageArray = self._applyBinning(self.imageArray.copy())
 
-  def _initCalculation(self):
-    self.targetVoxelArray = self.imageArray[self.labelledVoxelCoordinates].astype('float')
-    self.discretizedTargetVoxelArray = None  # Lazy instantiation
+  def _initVoxelBasedCalculation(self):
+    super(RadiomicsFirstOrder, self)._initVoxelBasedCalculation()
+
+    kernelRadius = self.settings.get('kernelRadius', 1)
+
+    ROI_mask = sitk.GetArrayFromImage(self.inputMask) == self.label
+    ROI_indices = numpy.array(numpy.where(ROI_mask))
+
+    # Get the size of the input, which depends on whether it is in masked mode or not
+    if self.masked:
+      size = numpy.max(ROI_indices, 1) - numpy.min(ROI_indices, 1) + 1
+    else:
+      size = numpy.array(self.imageArray.shape)
+
+    # Take the minimum size along each x, y and z dimension from either the size of the ROI or the kernel
+    # First add the kernel radius to the size, yielding shape (2, 3), then take the minimum along axis 0, getting back
+    # to shape (3,)
+    boundingBoxSize = numpy.min(numpy.insert([size], 1, kernelRadius * 2 + 1, axis=0), axis=0)
+
+    # Calculate the offsets, which can be used to generate a list of kernel Coordinates. Shape (Nd, Nk)
+    self.kernelOffsets = cMatrices.generate_angles(boundingBoxSize,
+                                                   numpy.array(range(1, kernelRadius + 1)),
+                                                   True,  # Bi-directional
+                                                   self.settings.get('force2D', False),
+                                                   self.settings.get('force2Ddimension', 0))
+    self.kernelOffsets = numpy.append(self.kernelOffsets, [[0, 0, 0]], axis=0)  # add center voxel
+    self.kernelOffsets = self.kernelOffsets.transpose((1, 0))
+
+    self.imageArray = self.imageArray.astype('float')
+    self.imageArray[~self.maskArray] = numpy.nan
+    self.imageArray = numpy.pad(self.imageArray,
+                                pad_width=self.settings.get('kernelRadius', 1),
+                                mode='constant', constant_values=numpy.nan)
+    self.maskArray = numpy.pad(self.maskArray,
+                               pad_width=self.settings.get('kernelRadius', 1),
+                               mode='constant', constant_values=False)
+
+  def _initCalculation(self, voxelCoordinates=None):
+
+    if voxelCoordinates is None:
+      self.targetVoxelArray = self.imageArray[self.maskArray].astype('float').reshape((1, -1))
+      _, p_i = numpy.unique(self.discretizedImageArray[self.maskArray], return_counts=True)
+      p_i = p_i.reshape((1, -1))
+    else:
+      # voxelCoordinates shape (Nd, Nvox)
+      voxelCoordinates = numpy.array(voxelCoordinates) + self.settings.get('kernelRadius', 1)  # adjust for padding
+      kernelCoords = self.kernelOffsets[:, None, :] + voxelCoordinates[:, :, None]  # Shape (Nd, Nvox, Nk)
+      kernelCoords = tuple(kernelCoords)  # shape (Nd, (Nvox, Nk))
+
+      self.targetVoxelArray = self.imageArray[kernelCoords]  # shape (Nvox, Nk)
+
+      p_i = numpy.empty((voxelCoordinates.shape[1], len(self.coefficients['grayLevels'])))  # shape (Nvox, Ng)
+      for gl_idx, gl in enumerate(self.coefficients['grayLevels']):
+        p_i[:, gl_idx] = numpy.nansum(self.discretizedImageArray[kernelCoords] == gl, 1)
+
+    sumBins = numpy.sum(p_i, 1, keepdims=True).astype('float')
+    sumBins[sumBins == 0] = 1  # Prevent division by 0 errors
+    p_i = p_i.astype('float') / sumBins
+    self.coefficients['p_i'] = p_i
 
     self.logger.debug('First order feature class initialized')
 
   @staticmethod
-  def _moment(a, moment=1, axis=0):
+  def _moment(a, moment=1):
     r"""
     Calculate n-order moment of an array for a given axis
     """
 
     if moment == 1:
-      return numpy.float64(0.0)
+      return numpy.float(0.0)
     else:
-      mn = numpy.mean(a, axis, keepdims=True)
+      mn = numpy.nanmean(a, 1, keepdims=True)
       s = numpy.power((a - mn), moment)
-      return numpy.mean(s, axis)
-
-  def _getDiscretizedTargetVoxelArray(self):
-    if self.discretizedTargetVoxelArray is None:
-      binEdges = imageoperations.getBinEdges(self.targetVoxelArray, **self.settings)
-
-      self.discretizedTargetVoxelArray = numpy.histogram(self.targetVoxelArray, binEdges)[0]
-
-    return self.discretizedTargetVoxelArray
+      return numpy.nanmean(s, 1)
 
   def getEnergyFeatureValue(self):
     r"""
@@ -81,7 +132,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
     shiftedParameterArray = self.targetVoxelArray + self.voxelArrayShift
 
-    return numpy.sum(shiftedParameterArray ** 2)
+    return numpy.nansum(shiftedParameterArray ** 2, 1)
 
   def getTotalEnergyFeatureValue(self):
     r"""
@@ -105,7 +156,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
     cubicMMPerVoxel = numpy.multiply.reduce(self.pixelSpacing)
 
-    return cubicMMPerVoxel * self.getEnergyFeatureValue()
+    return self.getEnergyFeatureValue() * cubicMMPerVoxel
 
   def getEntropyFeatureValue(self):
     r"""
@@ -122,17 +173,10 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     .. note::
       Defined by IBSI as Intensity Histogram Entropy.
     """
+    p_i = self.coefficients['p_i']
 
     eps = numpy.spacing(1)
-    bins = self._getDiscretizedTargetVoxelArray()
-
-    sumBins = bins.sum()
-    if sumBins == 0:  # No segmented voxels
-      return 0
-
-    bins = bins + eps
-    bins = bins / float(sumBins)
-    return -1.0 * numpy.sum(bins * numpy.log2(bins))
+    return -1.0 * numpy.sum(p_i * numpy.log2(p_i + eps), 1)
 
   def getMinimumFeatureValue(self):
     r"""
@@ -142,7 +186,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
       \textit{minimum} = \min(\textbf{X})
     """
 
-    return numpy.min(self.targetVoxelArray)
+    return numpy.nanmin(self.targetVoxelArray, 1)
 
   def get10PercentileFeatureValue(self):
     r"""
@@ -150,8 +194,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
     The 10\ :sup:`th` percentile of :math:`\textbf{X}`
     """
-
-    return numpy.percentile(self.targetVoxelArray, 10)
+    return numpy.nanpercentile(self.targetVoxelArray, 10, axis=1)
 
   def get90PercentileFeatureValue(self):
     r"""
@@ -160,7 +203,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     The 90\ :sup:`th` percentile of :math:`\textbf{X}`
     """
 
-    return numpy.percentile(self.targetVoxelArray, 90)
+    return numpy.nanpercentile(self.targetVoxelArray, 90, axis=1)
 
   def getMaximumFeatureValue(self):
     r"""
@@ -172,7 +215,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     The maximum gray level intensity within the ROI.
     """
 
-    return numpy.max(self.targetVoxelArray)
+    return numpy.nanmax(self.targetVoxelArray, 1)
 
   def getMeanFeatureValue(self):
     r"""
@@ -184,7 +227,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     The average gray level intensity within the ROI.
     """
 
-    return numpy.mean(self.targetVoxelArray)
+    return numpy.nanmean(self.targetVoxelArray, 1)
 
   def getMedianFeatureValue(self):
     r"""
@@ -193,7 +236,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     The median gray level intensity within the ROI.
     """
 
-    return numpy.median(self.targetVoxelArray)
+    return numpy.nanmedian(self.targetVoxelArray, 1)
 
   def getInterquartileRangeFeatureValue(self):
     r"""
@@ -206,7 +249,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     image array, respectively.
     """
 
-    return numpy.percentile(self.targetVoxelArray, 75) - numpy.percentile(self.targetVoxelArray, 25)
+    return numpy.nanpercentile(self.targetVoxelArray, 75, 1) - numpy.nanpercentile(self.targetVoxelArray, 25, 1)
 
   def getRangeFeatureValue(self):
     r"""
@@ -218,7 +261,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     The range of gray values in the ROI.
     """
 
-    return numpy.max(self.targetVoxelArray) - numpy.min(self.targetVoxelArray)
+    return numpy.nanmax(self.targetVoxelArray, 1) - numpy.nanmin(self.targetVoxelArray, 1)
 
   def getMeanAbsoluteDeviationFeatureValue(self):
     r"""
@@ -230,7 +273,8 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     Mean Absolute Deviation is the mean distance of all intensity values from the Mean Value of the image array.
     """
 
-    return numpy.mean(numpy.absolute((numpy.mean(self.targetVoxelArray) - self.targetVoxelArray)))
+    u_x = numpy.nanmean(self.targetVoxelArray, 1, keepdims=True)
+    return numpy.nanmean(numpy.absolute(self.targetVoxelArray - u_x), 1)
 
   def getRobustMeanAbsoluteDeviationFeatureValue(self):
     r"""
@@ -247,9 +291,11 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
 
     prcnt10 = self.get10PercentileFeatureValue()
     prcnt90 = self.get90PercentileFeatureValue()
-    percentileArray = self.targetVoxelArray[(self.targetVoxelArray >= prcnt10) * (self.targetVoxelArray <= prcnt90)]
+    percentileArray = self.targetVoxelArray.copy()
+    percentileArray[percentileArray - prcnt10[:, None] < 0] = numpy.nan
+    percentileArray[percentileArray - prcnt90[:, None] > 0] = numpy.nan
 
-    return numpy.mean(numpy.absolute(percentileArray - numpy.mean(percentileArray)))
+    return numpy.nanmean(numpy.absolute(percentileArray - numpy.nanmean(percentileArray, 1, keepdims=True)), 1)
 
   def getRootMeanSquaredFeatureValue(self):
     r"""
@@ -272,7 +318,8 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
       return 0
 
     shiftedParameterArray = self.targetVoxelArray + self.voxelArrayShift
-    return numpy.sqrt((numpy.sum(shiftedParameterArray ** 2)) / float(shiftedParameterArray.size))
+    Nvox = numpy.sum(~numpy.isnan(self.targetVoxelArray), 1).astype('float')
+    return numpy.sqrt(numpy.nansum(shiftedParameterArray ** 2, 1) / Nvox)
 
   @deprecated
   def getStandardDeviationFeatureValue(self):
@@ -293,9 +340,9 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
       Not present in IBSI feature definitions (correlated with variance)
     """
 
-    return numpy.std(self.targetVoxelArray)
+    return numpy.nanstd(self.targetVoxelArray, axis=1)
 
-  def getSkewnessFeatureValue(self, axis=0):
+  def getSkewnessFeatureValue(self):
     r"""
     **16. Skewness**
 
@@ -318,15 +365,15 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
       value of 0 is returned.
     """
 
-    m2 = self._moment(self.targetVoxelArray, 2, axis)
-    m3 = self._moment(self.targetVoxelArray, 3, axis)
+    m2 = self._moment(self.targetVoxelArray, 2)
+    m3 = self._moment(self.targetVoxelArray, 3)
 
-    if m2 == 0:  # Flat Region
-      return 0
+    m2[m2 == 0] = 1  # Flat Region, prevent division by 0 errors
+    m3[m2 == 0] = 0  # ensure Flat Regions are returned as 0
 
     return m3 / m2 ** 1.5
 
-  def getKurtosisFeatureValue(self, axis=0):
+  def getKurtosisFeatureValue(self):
     r"""
     **17. Kurtosis**
 
@@ -354,11 +401,11 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
       distributions. The PyRadiomics kurtosis is not corrected, yielding a value 3 higher than the IBSI kurtosis.
     """
 
-    m2 = self._moment(self.targetVoxelArray, 2, axis)
-    m4 = self._moment(self.targetVoxelArray, 4, axis)
+    m2 = self._moment(self.targetVoxelArray, 2)
+    m4 = self._moment(self.targetVoxelArray, 4)
 
-    if m2 == 0:  # Flat Region
-      return 0
+    m2[m2 == 0] = 1  # Flat Region, prevent division by 0 errors
+    m4[m2 == 0] = 0  # ensure Flat Regions are returned as 0
 
     return m4 / m2 ** 2.0
 
@@ -373,7 +420,7 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     the spread of the distribution about the mean. By definition, :math:`\textit{variance} = \sigma^2`
     """
 
-    return numpy.std(self.targetVoxelArray) ** 2
+    return numpy.nanstd(self.targetVoxelArray, 1) ** 2
 
   def getUniformityFeatureValue(self):
     r"""
@@ -389,13 +436,5 @@ class RadiomicsFirstOrder(base.RadiomicsFeaturesBase):
     .. note::
       Defined by IBSI as Intensity Histogram Uniformity.
     """
-
-    eps = numpy.spacing(1)
-    bins = self._getDiscretizedTargetVoxelArray()
-    sumBins = bins.sum()
-
-    if sumBins == 0:  # No segmented voxels
-      return 0
-
-    bins = bins / (float(sumBins + eps))
-    return numpy.sum(bins ** 2)
+    p_i = self.coefficients['p_i']
+    return numpy.nansum(p_i ** 2, 1)

--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -54,8 +54,8 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
 
   - distances [[1]]: List of integers. This specifies the distances between the center voxel and the neighbor, for which
     angles should be generated.
-  - gldm_a [0]: float, :math:`\alpha` cutoff value for dependence. A neighbouring voxel with gray level :math:`j` is considered
-    dependent on center voxel with gray level :math:`i` if :math:`|i-j|\le\alpha`
+  - gldm_a [0]: float, :math:`\alpha` cutoff value for dependence. A neighbouring voxel with gray level :math:`j` is
+    considered dependent on center voxel with gray level :math:`i` if :math:`|i-j|\le\alpha`
 
   References:
 
@@ -72,8 +72,6 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     self._applyBinning()
 
   def _initCalculation(self):
-    self.coefficients['Np'] = len(self.labelledVoxelCoordinates[0])
-
     self.P_gldm = self._calculateMatrix()
 
     self.logger.debug('Feature class initialized, calculated GLDM with shape %s', self.P_gldm.shape)
@@ -82,6 +80,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     self.logger.debug('Calculating GLDM matrix in C')
 
     Ng = self.coefficients['Ng']
+    # shape (Nv, Ng, Nd)
     P_gldm = cMatrices.calculate_gldm(self.matrix,
                                       self.maskArray,
                                       numpy.array(self.settings.get('distances', [1])),
@@ -95,17 +94,25 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
     emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
 
-    P_gldm = numpy.delete(P_gldm, emptyGrayLevels - 1, 0)
+    P_gldm = numpy.delete(P_gldm, emptyGrayLevels - 1, 1)
 
-    jvector = numpy.arange(1, P_gldm.shape[1] + 1, dtype='float64')
+    jvector = numpy.arange(1, P_gldm.shape[2] + 1, dtype='float64')
 
-    pd = numpy.sum(P_gldm, 0)
-    pg = numpy.sum(P_gldm, 1)
+    # shape (Nv, Nd)
+    pd = numpy.sum(P_gldm, 1)
+    # shape (Nv, Ng)
+    pg = numpy.sum(P_gldm, 2)
 
     # Delete columns that dependence sizes not present in the ROI
-    P_gldm = numpy.delete(P_gldm, numpy.where(pd == 0), 1)
-    jvector = numpy.delete(jvector, numpy.where(pd == 0))
-    pd = numpy.delete(pd, numpy.where(pd == 0))
+    empty_sizes = numpy.sum(pd, 0)
+    P_gldm = numpy.delete(P_gldm, numpy.where(empty_sizes == 0), 2)
+    jvector = numpy.delete(jvector, numpy.where(empty_sizes == 0))
+    pd = numpy.delete(pd, numpy.where(empty_sizes == 0), 1)
+
+    Nz = numpy.sum(pd, 1)  # Nz per kernel, shape (Nv, )
+    Nz[Nz == 0] = 1  # set sum to numpy.spacing(1) if sum is 0?
+
+    self.coefficients['Nz'] = Nz
 
     self.coefficients['pd'] = pd
     self.coefficients['pg'] = pg
@@ -127,13 +134,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     pd = self.coefficients['pd']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
+    Nz = self.coefficients['Nz']  # Nz = Np, see class docstring
 
-    try:
-      sde = numpy.sum(pd / (jvector ** 2)) / Nz
-      return sde
-    except ZeroDivisionError:
-      return numpy.core.nan
+    sde = numpy.sum(pd / (jvector[None, :] ** 2), 1) / Nz
+    return sde
 
   def getLargeDependenceEmphasisFeatureValue(self):
     r"""
@@ -147,13 +151,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     pd = self.coefficients['pd']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
+    Nz = self.coefficients['Nz']
 
-    try:
-      lre = numpy.sum(pd * (jvector ** 2)) / Nz
-      return lre
-    except ZeroDivisionError:
-      return numpy.core.nan
+    lre = numpy.sum(pd * (jvector[None, :] ** 2), 1) / Nz
+    return lre
 
   def getGrayLevelNonUniformityFeatureValue(self):
     r"""
@@ -166,29 +167,29 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     correlates with a greater similarity in intensity values.
     """
     pg = self.coefficients['pg']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
+    Nz = self.coefficients['Nz']
 
-    try:
-      gln = numpy.sum(pg ** 2) / Nz
-      return gln
-    except ZeroDivisionError:
-      return numpy.core.nan
+    gln = numpy.sum(pg ** 2, 1) / Nz
+    return gln
 
   @deprecated
   def getGrayLevelNonUniformityNormalizedFeatureValue(self):
     r"""
     **DEPRECATED. Gray Level Non-Uniformity Normalized (GLNN)**
 
-    :math:`GLNN = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_d}_{j=1}{\textbf{P}(i,j)}\right)^2}{\sum^{N_g}_{i=1}\sum^{N_d}_{j=1}{\textbf{P}(i,j)}^2}`
+    :math:`GLNN = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_d}_{j=1}{\textbf{P}(i,j)}\right)^2}{\sum^{N_g}_{i=1}
+    \sum^{N_d}_{j=1}{\textbf{P}(i,j)}^2}`
 
     .. warning::
       This feature has been deprecated, as it is mathematically equal to First Order - Uniformity
       :py:func:`~radiomics.firstorder.RadiomicsFirstOrder.getUniformityFeatureValue()`.
       See :ref:`here <radiomics-excluded-gldm-glnn-label>` for the proof. **Enabling this feature will result in the
-      logging of a DeprecationWarning (does not interrupt extraction of other features), no value is calculated for this features**
+      logging of a DeprecationWarning (does not interrupt extraction of other features), no value is calculated for
+      this feature**
     """
-    raise DeprecationWarning('GLDM - Gray Level Non-Uniformity Normalized is mathematically equal to First Order - Uniformity, '
-                             'see http://pyradiomics.readthedocs.io/en/latest/removedfeatures.html for more details')
+    raise DeprecationWarning('GLDM - Gray Level Non-Uniformity Normalized is mathematically equal to First Order - '
+                             'Uniformity, see http://pyradiomics.readthedocs.io/en/latest/removedfeatures.html for more'
+                             'details')
 
   def getDependenceNonUniformityFeatureValue(self):
     r"""
@@ -201,13 +202,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     more homogeneity among dependencies in the image.
     """
     pd = self.coefficients['pd']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
+    Nz = self.coefficients['Nz']
 
-    try:
-      dn = numpy.sum(pd ** 2) / Nz
-      return dn
-    except ZeroDivisionError:
-      return numpy.core.nan
+    dn = numpy.sum(pd ** 2, 1) / Nz
+    return dn
 
   def getDependenceNonUniformityNormalizedFeatureValue(self):
     r"""
@@ -220,13 +218,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     more homogeneity among dependencies in the image. This is the normalized version of the DLN formula.
     """
     pd = self.coefficients['pd']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
+    Nz = self.coefficients['Nz']
 
-    try:
-      dnn = numpy.sum(pd ** 2) / (Nz ** 2)
-      return dnn
-    except ZeroDivisionError:
-      return numpy.core.nan
+    dnn = numpy.sum(pd ** 2, 1) / Nz ** 2
+    return dnn
 
   def getGrayLevelVarianceFeatureValue(self):
     r"""
@@ -239,11 +234,11 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     Measures the variance in grey level in the image.
     """
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
-    pg = self.coefficients['pg'] / Nz  # divide by Nz to get the normalized matrix
+    Nz = self.coefficients['Nz']
+    pg = self.coefficients['pg'] / Nz[:, None]  # divide by Nz to get the normalized matrix
 
-    u_i = numpy.sum(pg * ivector)
-    glv = numpy.sum(pg * (ivector - u_i) ** 2)
+    u_i = numpy.sum(pg * ivector[None, :], 1, keepdims=True)
+    glv = numpy.sum(pg * (ivector[None, :] - u_i) ** 2, 1)
     return glv
 
   def getDependenceVarianceFeatureValue(self):
@@ -257,11 +252,11 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     Measures the variance in dependence size in the image.
     """
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
-    pd = self.coefficients['pd'] / Nz  # divide by Nz to get the normalized matrix
+    Nz = self.coefficients['Nz']
+    pd = self.coefficients['pd'] / Nz[:, None]  # divide by Nz to get the normalized matrix
 
-    u_j = numpy.sum(pd * jvector)
-    dv = numpy.sum(pd * (jvector - u_j) ** 2)
+    u_j = numpy.sum(pd * jvector[None, :], 1, keepdims=True)
+    dv = numpy.sum(pd * (jvector[None, :] - u_j) ** 2, 1)
     return dv
 
   def getDependenceEntropyFeatureValue(self):
@@ -272,10 +267,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
       Dependence Entropy = -\displaystyle\sum^{N_g}_{i=1}\displaystyle\sum^{N_d}_{j=1}{p(i,j)\log_{2}(p(i,j)+\epsilon)}
     """
     eps = numpy.spacing(1)
-    Nz = self.coefficients['Np']  # Nz = Np, see class docstring
-    p_gldm = self.P_gldm / Nz  # divide by Nz to get the normalized matrix
+    Nz = self.coefficients['Nz']
+    p_gldm = self.P_gldm / Nz[:, None, None]  # divide by Nz to get the normalized matrix
 
-    return -numpy.sum(p_gldm * numpy.log2(p_gldm + eps))
+    return -numpy.sum(p_gldm * numpy.log2(p_gldm + eps), (1, 2))
 
   @deprecated
   def getDependencePercentageFeatureValue(self):
@@ -287,8 +282,9 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
 
     .. warning::
       This feature has been deprecated, as it would always compute 1. See
-      :ref:`here <radiomics-excluded-gldm-dependence-percentage-label>` for more details. **Enabling this feature will result in the
-      logging of a DeprecationWarning (does not interrupt extraction of other features), no value is calculated for this features**
+      :ref:`here <radiomics-excluded-gldm-dependence-percentage-label>` for more details. **Enabling this feature will
+      result in the logging of a DeprecationWarning (does not interrupt extraction of other features), no value is
+      calculated for this features**
     """
     raise DeprecationWarning('GLDM - Dependence Percentage always computes 1, '
                              'see http://pyradiomics.readthedocs.io/en/latest/removedfeatures.html for more details')
@@ -305,13 +301,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     pg = self.coefficients['pg']
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      lgle = numpy.sum(pg / (ivector ** 2)) / Nz
-      return lgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    lgle = numpy.sum(pg / (ivector[None, :] ** 2), 1) / Nz
+    return lgle
 
   def getHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -325,13 +318,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     pg = self.coefficients['pg']
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      hgle = numpy.sum(pg * (ivector ** 2)) / Nz
-      return hgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    hgle = numpy.sum(pg * (ivector[None, :] ** 2), 1) / Nz
+    return hgle
 
   def getSmallDependenceLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -344,13 +334,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      sdlgle = numpy.sum(self.P_gldm / ((ivector[:, None] ** 2) * (jvector[None, :] ** 2))) / Nz
-      return sdlgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    sdlgle = numpy.sum(self.P_gldm / ((ivector[None, :, None] ** 2) * (jvector[None, None, :] ** 2)), (1, 2)) / Nz
+    return sdlgle
 
   def getSmallDependenceHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -363,13 +350,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      sdhgle = numpy.sum(self.P_gldm * (ivector[:, None] ** 2) / (jvector[None, :] ** 2)) / Nz
-      return sdhgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    sdhgle = numpy.sum(self.P_gldm * (ivector[None, :, None] ** 2) / (jvector[None, None, :] ** 2), (1, 2)) / Nz
+    return sdhgle
 
   def getLargeDependenceLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -382,13 +366,10 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      ldlgle = numpy.sum(self.P_gldm * (jvector[None, :] ** 2) / (ivector[:, None] ** 2)) / Nz
-      return ldlgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    ldlgle = numpy.sum(self.P_gldm * (jvector[None, None, :] ** 2) / (ivector[None, :, None] ** 2), (1, 2)) / Nz
+    return ldlgle
 
   def getLargeDependenceHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -401,10 +382,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Np']
+    Nz = self.coefficients['Nz']
 
-    try:
-      ldhgle = numpy.sum(self.P_gldm * ((jvector[None, :] ** 2) * (ivector[:, None] ** 2))) / Nz
-      return ldhgle
-    except ZeroDivisionError:
-      return numpy.core.nan
+    ldhgle = numpy.sum(self.P_gldm * ((jvector[None, None, :] ** 2) * (ivector[None, :, None] ** 2)), (1, 2)) / Nz
+    return ldhgle

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -35,11 +35,11 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
   - :math:`N_g` be the number of discreet intensity values in the image
   - :math:`N_r` be the number of discreet run lengths in the image
   - :math:`N_p` be the number of voxels in the image
-  - :math:`N_z(\theta)` be the number of runs in the image along angle :math:`\theta`, which is equal to
-    :math:`\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}` and :math:`1 \leq N_z(\theta) \leq N_p`
+  - :math:`N_r(\theta)` be the number of runs in the image along angle :math:`\theta`, which is equal to
+    :math:`\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}` and :math:`1 \leq N_r(\theta) \leq N_p`
   - :math:`\textbf{P}(i,j|\theta)` be the run length matrix for an arbitrary direction :math:`\theta`
   - :math:`p(i,j|\theta)` be the normalized run length matrix, defined as :math:`p(i,j|\theta) =
-    \frac{\textbf{P}(i,j|\theta)}{N_z(\theta)}`
+    \frac{\textbf{P}(i,j|\theta)}{N_r(\theta)}`
 
   By default, the value of a feature is calculated on the GLRLM for each angle separately, after which the mean of these
   values is returned. If distance weighting is enabled, GLRLMs are weighted by the distance between neighbouring voxels
@@ -81,9 +81,6 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     self._applyBinning()
 
   def _initCalculation(self):
-    self.coefficients['Nr'] = numpy.max(self.matrix.shape)
-    self.coefficients['Np'] = len(self.labelledVoxelCoordinates[0])
-
     self.P_glrlm = self._calculateMatrix()
 
     self._calculateCoefficients()
@@ -94,10 +91,11 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     self.logger.debug('Calculating GLRLM matrix in C')
 
     Ng = self.coefficients['Ng']
+    Nr = numpy.max(self.matrix.shape)
     P_glrlm, angles = cMatrices.calculate_glrlm(self.matrix,
                                                 self.maskArray,
                                                 Ng,
-                                                self.coefficients['Nr'],
+                                                Nr,
                                                 self.settings.get('force2D', False),
                                                 self.settings.get('force2Ddimension', 0))
 
@@ -108,13 +106,11 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
     emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
 
-    P_glrlm = numpy.delete(P_glrlm, emptyGrayLevels - 1, 0)
+    P_glrlm = numpy.delete(P_glrlm, emptyGrayLevels - 1, 1)
 
     # Optionally apply a weighting factor
     if self.weightingNorm is not None:
       self.logger.debug('Applying weighting (%s)', self.weightingNorm)
-      # Correct the number of voxels for the number of times it is used (once per angle), affects run percentage
-      self.coefficients['Np'] *= len(angles)
 
       pixelSpacing = self.inputImage.GetSpacing()[::-1]
       weights = numpy.empty(len(angles))
@@ -131,39 +127,43 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
           self.logger.warning('weigthing norm "%s" is unknown, weighting factor is set to 1', self.weightingNorm)
           weights[a_idx] = 1
 
-      P_glrlm = numpy.sum(P_glrlm * weights[None, None, :], 2, keepdims=True)
+      P_glrlm = numpy.sum(P_glrlm * weights[None, None, None, :], 3, keepdims=True)
 
-    Nz = numpy.sum(P_glrlm, (0, 1))
+    Nr = numpy.sum(P_glrlm, (1, 2))
 
     # Delete empty angles if no weighting is applied
-    if P_glrlm.shape[2] > 1:
-      emptyAngles = numpy.where(Nz == 0)
+    if P_glrlm.shape[3] > 1:
+      emptyAngles = numpy.where(numpy.sum(Nr, 0) == 0)
       if len(emptyAngles[0]) > 0:  # One or more angles are 'empty'
         self.logger.debug('Deleting %d empty angles:\n%s', len(emptyAngles[0]), angles[emptyAngles])
-        P_glrlm = numpy.delete(P_glrlm, emptyAngles, 2)
-        Nz = numpy.delete(Nz, emptyAngles, 0)
+        P_glrlm = numpy.delete(P_glrlm, emptyAngles, 3)
+        Nr = numpy.delete(Nr, emptyAngles, 1)
       else:
         self.logger.debug('No empty angles')
 
-    self.coefficients['Nz'] = Nz
+    Nr[Nr == 0] = 1  # set sum to numpy.spacing(1) if sum is 0?
+    self.coefficients['Nr'] = Nr
 
     return P_glrlm
 
   def _calculateCoefficients(self):
     self.logger.debug('Calculating GLRLM coefficients')
 
-    pr = numpy.sum(self.P_glrlm, 0)
-    pg = numpy.sum(self.P_glrlm, 1)
+    pr = numpy.sum(self.P_glrlm, 1)  # shape (Nvox, Nr, Na)
+    pg = numpy.sum(self.P_glrlm, 2)  # shape (Nvox, Ng, Na)
 
-    ivector = self.coefficients['grayLevels']
-    jvector = numpy.arange(1, self.P_glrlm.shape[1] + 1, dtype=numpy.float64)
+    ivector = self.coefficients['grayLevels']  # shape (Ng,)
+    jvector = numpy.arange(1, self.P_glrlm.shape[2] + 1, dtype=numpy.float64)  # shape (Nr,)
 
     # Delete columns that run lengths not present in the ROI
-    emptyRunLenghts = numpy.where(numpy.sum(pr, 1) == 0)
-    self.P_glrlm = numpy.delete(self.P_glrlm, emptyRunLenghts, 1)
+    emptyRunLenghts = numpy.where(numpy.sum(pr, (0, 2)) == 0)
+    self.P_glrlm = numpy.delete(self.P_glrlm, emptyRunLenghts, 2)
     jvector = numpy.delete(jvector, emptyRunLenghts)
-    pr = numpy.delete(pr, emptyRunLenghts, 0)
+    pr = numpy.delete(pr, emptyRunLenghts, 1)
 
+    Np = numpy.sum(pr[:, :, 0] * jvector[None, :], 1)  # shape (Nvox,)
+
+    self.coefficients['Np'] = Np
     self.coefficients['pr'] = pr
     self.coefficients['pg'] = pg
     self.coefficients['ivector'] = ivector
@@ -174,105 +174,105 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     **1. Short Run Emphasis (SRE)**
 
     .. math::
-      \textit{SRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{j^2}}}{N_z(\theta)}
+      \textit{SRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{j^2}}}{N_r(\theta)}
 
     SRE is a measure of the distribution of short run lengths, with a greater value indicative of shorter run lengths
     and more fine textural textures.
     """
     pr = self.coefficients['pr']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    sre = numpy.sum((pr / (jvector[:, None] ** 2)), 0) / Nz
-    return sre.mean()
+    sre = numpy.sum((pr / (jvector[None, :, None] ** 2)), 1) / Nr
+    return sre.mean(1)
 
   def getLongRunEmphasisFeatureValue(self):
     r"""
     **2. Long Run Emphasis (LRE)**
 
     .. math::
-      \textit{LRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)j^2}}{N_z(\theta)}
+      \textit{LRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)j^2}}{N_r(\theta)}
 
     LRE is a measure of the distribution of long run lengths, with a greater value indicative of longer run lengths and
     more coarse structural textures.
     """
     pr = self.coefficients['pr']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    lre = numpy.sum((pr * (jvector[:, None] ** 2)), 0) / Nz
-    return lre.mean()
+    lre = numpy.sum((pr * (jvector[None, :, None] ** 2)), 1) / Nr
+    return lre.mean(1)
 
   def getGrayLevelNonUniformityFeatureValue(self):
     r"""
     **3. Gray Level Non-Uniformity (GLN)**
 
     .. math::
-      \textit{GLN} = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_z(\theta)}
+      \textit{GLN} = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_r(\theta)}
 
     GLN measures the similarity of gray-level intensity values in the image, where a lower GLN value correlates with a
     greater similarity in intensity values.
     """
     pg = self.coefficients['pg']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    gln = numpy.sum((pg ** 2), 0) / Nz
-    return gln.mean()
+    gln = numpy.sum((pg ** 2), 1) / Nr
+    return gln.mean(1)
 
   def getGrayLevelNonUniformityNormalizedFeatureValue(self):
     r"""
     **4. Gray Level Non-Uniformity Normalized (GLNN)**
 
     .. math::
-      \textit{GLNN} = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_z(\theta)^2}
+      \textit{GLNN} = \frac{\sum^{N_g}_{i=1}\left(\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_r(\theta)^2}
 
     GLNN measures the similarity of gray-level intensity values in the image, where a lower GLNN value correlates with a
     greater similarity in intensity values. This is the normalized version of the GLN formula.
     """
     pg = self.coefficients['pg']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    glnn = numpy.sum(pg ** 2, 0) / (Nz ** 2)
-    return glnn.mean()
+    glnn = numpy.sum(pg ** 2, 1) / (Nr ** 2)
+    return glnn.mean(1)
 
   def getRunLengthNonUniformityFeatureValue(self):
     r"""
     **5. Run Length Non-Uniformity (RLN)**
 
     .. math::
-      \textit{RLN} = \frac{\sum^{N_r}_{j=1}\left(\sum^{N_g}_{i=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_z(\theta)}
+      \textit{RLN} = \frac{\sum^{N_r}_{j=1}\left(\sum^{N_g}_{i=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_r(\theta)}
 
     RLN measures the similarity of run lengths throughout the image, with a lower value indicating more homogeneity
     among run lengths in the image.
     """
     pr = self.coefficients['pr']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    rln = numpy.sum((pr ** 2), 0) / Nz
-    return rln.mean()
+    rln = numpy.sum((pr ** 2), 1) / Nr
+    return rln.mean(1)
 
   def getRunLengthNonUniformityNormalizedFeatureValue(self):
     r"""
     **6. Run Length Non-Uniformity Normalized (RLNN)**
 
     .. math::
-      \textit{RLNN} = \frac{\sum^{N_r}_{j=1}\left(\sum^{N_g}_{i=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_z(\theta)^2}
+      \textit{RLNN} = \frac{\sum^{N_r}_{j=1}\left(\sum^{N_g}_{i=1}{\textbf{P}(i,j|\theta)}\right)^2}{N_r(\theta)^2}
 
     RLNN measures the similarity of run lengths throughout the image, with a lower value indicating more homogeneity
     among run lengths in the image. This is the normalized version of the RLN formula.
     """
     pr = self.coefficients['pr']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    rlnn = numpy.sum((pr ** 2), 0) / Nz ** 2
-    return rlnn.mean()
+    rlnn = numpy.sum((pr ** 2), 1) / Nr ** 2
+    return rlnn.mean(1)
 
   def getRunPercentageFeatureValue(self):
     r"""
     **7. Run Percentage (RP)**
 
     .. math::
-      \textit{RP} = {\frac{N_z(\theta)}{N_p}}
+      \textit{RP} = {\frac{N_r(\theta)}{N_p}}
 
     RP measures the coarseness of the texture by taking the ratio of number of runs and number of voxels in the ROI.
 
@@ -284,10 +284,10 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
       :math:`n` number of matrices merged to ensure correct normalization (as each voxel is considered :math:`n` times)
     """
     Np = self.coefficients['Np']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    rp = Nz / Np
-    return rp.mean()
+    rp = Nr / Np
+    return rp.mean(1)
 
   def getGrayLevelVarianceFeatureValue(self):
     r"""
@@ -301,12 +301,12 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     GLV measures the variance in gray level intensity for the runs.
     """
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Nz']
-    pg = self.coefficients['pg'] / Nz  # divide by Nz to get the normalized matrix
+    Nr = self.coefficients['Nr']
+    pg = self.coefficients['pg'] / Nr[:, None, :]  # divide by Nr to get the normalized matrix
 
-    u_i = numpy.sum(pg * ivector[:, None], 0)
-    glv = numpy.sum(pg * (ivector[:, None] - u_i[None, :]) ** 2, 0)
-    return glv.mean()
+    u_i = numpy.sum(pg * ivector[None, :, None], 1, keepdims=True)
+    glv = numpy.sum(pg * (ivector[None, :, None] - u_i) ** 2, 1)
+    return glv.mean(1)
 
   def getRunVarianceFeatureValue(self):
     r"""
@@ -320,12 +320,12 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     RV is a measure of the variance in runs for the run lengths.
     """
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
-    pr = self.coefficients['pr'] / Nz   # divide by Nz to get the normalized matrix
+    Nr = self.coefficients['Nr']
+    pr = self.coefficients['pr'] / Nr[:, None, :]   # divide by Nr to get the normalized matrix
 
-    u_j = numpy.sum(pr * jvector[:, None], 0)
-    rv = numpy.sum(pr * (jvector[:, None] - u_j[None, :]) ** 2, 0)
-    return rv.mean()
+    u_j = numpy.sum(pr * jvector[None, :, None], 1, keepdims=True)
+    rv = numpy.sum(pr * (jvector[None, :, None] - u_j) ** 2, 1)
+    return rv.mean(1)
 
   def getRunEntropyFeatureValue(self):
     r"""
@@ -341,110 +341,110 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     more heterogeneity in the texture patterns.
     """
     eps = numpy.spacing(1)
-    Nz = self.coefficients['Nz']
-    p_glrlm = self.P_glrlm / Nz  # divide by Nz to get the normalized matrix
+    Nr = self.coefficients['Nr']
+    p_glrlm = self.P_glrlm / Nr[:, None, None, :]  # divide by Nr to get the normalized matrix
 
-    re = -numpy.sum(p_glrlm * numpy.log2(p_glrlm + eps), (0, 1))
-    return re.mean()
+    re = -numpy.sum(p_glrlm * numpy.log2(p_glrlm + eps), (1, 2))
+    return re.mean(1)
 
   def getLowGrayLevelRunEmphasisFeatureValue(self):
     r"""
     **11. Low Gray Level Run Emphasis (LGLRE)**
 
     .. math::
-      \textit{LGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{i^2}}}{N_z(\theta)}
+      \textit{LGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{i^2}}}{N_r(\theta)}
 
     LGLRE measures the distribution of low gray-level values, with a higher value indicating a greater concentration of
     low gray-level values in the image.
     """
     pg = self.coefficients['pg']
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    lglre = numpy.sum((pg / (ivector[:, None] ** 2)), 0) / Nz
-    return lglre.mean()
+    lglre = numpy.sum((pg / (ivector[None, :, None] ** 2)), 1) / Nr
+    return lglre.mean(1)
 
   def getHighGrayLevelRunEmphasisFeatureValue(self):
     r"""
     **12. High Gray Level Run Emphasis (HGLRE)**
 
     .. math::
-      \textit{HGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)i^2}}{N_z(\theta)}
+      \textit{HGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)i^2}}{N_r(\theta)}
 
     HGLRE measures the distribution of the higher gray-level values, with a higher value indicating a greater
     concentration of high gray-level values in the image.
     """
     pg = self.coefficients['pg']
     ivector = self.coefficients['ivector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    hglre = numpy.sum((pg * (ivector[:, None] ** 2)), 0) / Nz
-    return hglre.mean()
+    hglre = numpy.sum((pg * (ivector[None, :, None] ** 2)), 1) / Nr
+    return hglre.mean(1)
 
   def getShortRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
     **13. Short Run Low Gray Level Emphasis (SRLGLE)**
 
     .. math::
-      \textit{SRLGLE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{i^2j^2}}}{N_z(\theta)}
+      \textit{SRLGLE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)}{i^2j^2}}}{N_r(\theta)}
 
     SRLGLE measures the joint distribution of shorter run lengths with lower gray-level values.
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    srlgle = numpy.sum((self.P_glrlm / ((ivector[:, None, None] ** 2) * (jvector[None, :, None] ** 2))),
-                       (0, 1)) / Nz
-    return srlgle.mean()
+    srlgle = numpy.sum((self.P_glrlm / ((ivector[None, :, None, None] ** 2) * (jvector[None, None, :, None] ** 2))),
+                       (1, 2)) / Nr
+    return srlgle.mean(1)
 
   def getShortRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
     **14. Short Run High Gray Level Emphasis (SRHGLE)**
 
     .. math::
-      \textit{SRHGLE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)i^2}{j^2}}}{N_z(\theta)}
+      \textit{SRHGLE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)i^2}{j^2}}}{N_r(\theta)}
 
     SRHGLE measures the joint distribution of shorter run lengths with higher gray-level values.
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    srhgle = numpy.sum((self.P_glrlm * (ivector[:, None, None] ** 2) / (jvector[None, :, None] ** 2)),
-                       (0, 1)) / Nz
-    return srhgle.mean()
+    srhgle = numpy.sum((self.P_glrlm * (ivector[None, :, None, None] ** 2) / (jvector[None, None, :, None] ** 2)),
+                       (1, 2)) / Nr
+    return srhgle.mean(1)
 
   def getLongRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
     **15. Long Run Low Gray Level Emphasis (LRLGLE)**
 
     .. math::
-      \textit{LRLGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)j^2}{i^2}}}{N_z(\theta)}
+      \textit{LRLGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\frac{\textbf{P}(i,j|\theta)j^2}{i^2}}}{N_r(\theta)}
 
     LRLGLRE measures the joint distribution of long run lengths with lower gray-level values.
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    lrlgle = numpy.sum((self.P_glrlm * (jvector[None, :, None] ** 2) / (ivector[:, None, None] ** 2)),
-                       (0, 1)) / Nz
-    return lrlgle.mean()
+    lrlgle = numpy.sum((self.P_glrlm * (jvector[None, None, :, None] ** 2) / (ivector[None, :, None, None] ** 2)),
+                       (1, 2)) / Nr
+    return lrlgle.mean(1)
 
   def getLongRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
     **16. Long Run High Gray Level Emphasis (LRHGLE)**
 
     .. math::
-      \textit{LRHGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)i^2j^2}}{N_z(\theta)}
+      \textit{LRHGLRE} = \frac{\sum^{N_g}_{i=1}\sum^{N_r}_{j=1}{\textbf{P}(i,j|\theta)i^2j^2}}{N_r(\theta)}
 
     LRHGLRE measures the joint distribution of long run lengths with higher gray-level values.
     """
     ivector = self.coefficients['ivector']
     jvector = self.coefficients['jvector']
-    Nz = self.coefficients['Nz']
+    Nr = self.coefficients['Nr']
 
-    lrhgle = numpy.sum((self.P_glrlm * ((jvector[None, :, None] ** 2) * (ivector[:, None, None] ** 2))),
-                       (0, 1)) / Nz
-    return lrhgle.mean()
+    lrhgle = numpy.sum((self.P_glrlm * ((jvector[None, None, :, None] ** 2) * (ivector[None, :, None, None] ** 2))),
+                       (1, 2)) / Nr
+    return lrhgle.mean(1)

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -148,7 +148,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
       else:
         self.logger.debug('No empty angles')
 
-    Nr[Nr == 0] = 1  # set sum to numpy.spacing(1) if sum is 0?
+    Nr[Nr == 0] = numpy.nan  # set sum to numpy.spacing(1) if sum is 0?
     self.coefficients['Nr'] = Nr
 
     return P_glrlm
@@ -168,10 +168,6 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     jvector = numpy.delete(jvector, emptyRunLenghts)
     pr = numpy.delete(pr, emptyRunLenghts, 1)
 
-    Np = numpy.sum(pr[:, :, 0] * jvector[None, :], 1, keepdims=True)  # shape (Nvox, 1)
-    Np[Np == 0] = 1
-
-    self.coefficients['Np'] = Np
     self.coefficients['pr'] = pr
     self.coefficients['pg'] = pg
     self.coefficients['ivector'] = ivector
@@ -192,7 +188,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     sre = numpy.sum((pr / (jvector[None, :, None] ** 2)), 1) / Nr
-    return sre.mean(1)
+    return numpy.nanmean(sre, 1)
 
   def getLongRunEmphasisFeatureValue(self):
     r"""
@@ -209,7 +205,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     lre = numpy.sum((pr * (jvector[None, :, None] ** 2)), 1) / Nr
-    return lre.mean(1)
+    return numpy.nanmean(lre, 1)
 
   def getGrayLevelNonUniformityFeatureValue(self):
     r"""
@@ -225,7 +221,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     gln = numpy.sum((pg ** 2), 1) / Nr
-    return gln.mean(1)
+    return numpy.nanmean(gln, 1)
 
   def getGrayLevelNonUniformityNormalizedFeatureValue(self):
     r"""
@@ -241,7 +237,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     glnn = numpy.sum(pg ** 2, 1) / (Nr ** 2)
-    return glnn.mean(1)
+    return numpy.nanmean(glnn, 1)
 
   def getRunLengthNonUniformityFeatureValue(self):
     r"""
@@ -257,7 +253,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     rln = numpy.sum((pr ** 2), 1) / Nr
-    return rln.mean(1)
+    return numpy.nanmean(rln, 1)
 
   def getRunLengthNonUniformityNormalizedFeatureValue(self):
     r"""
@@ -273,7 +269,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     rlnn = numpy.sum((pr ** 2), 1) / Nr ** 2
-    return rlnn.mean(1)
+    return numpy.nanmean(rlnn, 1)
 
   def getRunPercentageFeatureValue(self):
     r"""
@@ -291,11 +287,14 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
       Note that when weighting is applied and matrices are merged before calculation, :math:`N_p` is multiplied by
       :math:`n` number of matrices merged to ensure correct normalization (as each voxel is considered :math:`n` times)
     """
-    Np = self.coefficients['Np']
+    pr = self.coefficients['pr']
+    jvector = self.coefficients['jvector']
     Nr = self.coefficients['Nr']
 
+    Np = numpy.sum(pr * jvector[None, :, None], 1)  # shape (Nvox, Na)
+
     rp = Nr / Np
-    return rp.mean(1)
+    return numpy.nanmean(rp, 1)
 
   def getGrayLevelVarianceFeatureValue(self):
     r"""
@@ -314,7 +313,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     u_i = numpy.sum(pg * ivector[None, :, None], 1, keepdims=True)
     glv = numpy.sum(pg * (ivector[None, :, None] - u_i) ** 2, 1)
-    return glv.mean(1)
+    return numpy.nanmean(glv, 1)
 
   def getRunVarianceFeatureValue(self):
     r"""
@@ -333,7 +332,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     u_j = numpy.sum(pr * jvector[None, :, None], 1, keepdims=True)
     rv = numpy.sum(pr * (jvector[None, :, None] - u_j) ** 2, 1)
-    return rv.mean(1)
+    return numpy.nanmean(rv, 1)
 
   def getRunEntropyFeatureValue(self):
     r"""
@@ -353,7 +352,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     p_glrlm = self.P_glrlm / Nr[:, None, None, :]  # divide by Nr to get the normalized matrix
 
     re = -numpy.sum(p_glrlm * numpy.log2(p_glrlm + eps), (1, 2))
-    return re.mean(1)
+    return numpy.nanmean(re, 1)
 
   def getLowGrayLevelRunEmphasisFeatureValue(self):
     r"""
@@ -370,7 +369,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     lglre = numpy.sum((pg / (ivector[None, :, None] ** 2)), 1) / Nr
-    return lglre.mean(1)
+    return numpy.nanmean(lglre, 1)
 
   def getHighGrayLevelRunEmphasisFeatureValue(self):
     r"""
@@ -387,7 +386,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     Nr = self.coefficients['Nr']
 
     hglre = numpy.sum((pg * (ivector[None, :, None] ** 2)), 1) / Nr
-    return hglre.mean(1)
+    return numpy.nanmean(hglre, 1)
 
   def getShortRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -404,7 +403,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     srlgle = numpy.sum((self.P_glrlm / ((ivector[None, :, None, None] ** 2) * (jvector[None, None, :, None] ** 2))),
                        (1, 2)) / Nr
-    return srlgle.mean(1)
+    return numpy.nanmean(srlgle, 1)
 
   def getShortRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -421,7 +420,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     srhgle = numpy.sum((self.P_glrlm * (ivector[None, :, None, None] ** 2) / (jvector[None, None, :, None] ** 2)),
                        (1, 2)) / Nr
-    return srhgle.mean(1)
+    return numpy.nanmean(srhgle, 1)
 
   def getLongRunLowGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -438,7 +437,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     lrlgle = numpy.sum((self.P_glrlm * (jvector[None, None, :, None] ** 2) / (ivector[None, :, None, None] ** 2)),
                        (1, 2)) / Nr
-    return lrlgle.mean(1)
+    return numpy.nanmean(lrlgle, 1)
 
   def getLongRunHighGrayLevelEmphasisFeatureValue(self):
     r"""
@@ -455,4 +454,4 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
 
     lrhgle = numpy.sum((self.P_glrlm * ((jvector[None, None, :, None] ** 2) * (ivector[None, :, None, None] ** 2))),
                        (1, 2)) / Nr
-    return lrhgle.mean(1)
+    return numpy.nanmean(lrhgle, 1)

--- a/radiomics/schemas/paramSchema.yaml
+++ b/radiomics/schemas/paramSchema.yaml
@@ -141,6 +141,10 @@ mapping:
         type: bool
       initValue:
         type: float
+      voxelBatch:
+        type: int
+        range:
+          min-ex: 0
 
   featureClass:
     type: map

--- a/radiomics/src/_cmatrices.c
+++ b/radiomics/src/_cmatrices.c
@@ -30,6 +30,8 @@ static PyObject *cmatrices_generate_angles(PyObject *self, PyObject *args);
 // Function to check if array input is valid. Additionally extracts size and stride values
 int build_angles_arr(PyObject *distances_obj, PyArrayObject **angles_arr, int *size, int Nd, int force2Ddimension, int bidirectional, int *Na);
 int try_parse_arrays(PyObject *image_obj, PyObject *mask_obj, PyArrayObject **image_arr, PyArrayObject **mask_arr, int *Nd, int **size, int **strides, int mask_flags);
+int try_parse_voxels_arr(PyObject *voxels_obj, PyArrayObject **voxels_arr, int Nd, int *vox_cnt, int kernelRadius);
+void set_bb(int v, int *bb, int *size, int *voxels, int Nd, int Nvox, int kernelRadius, int force2Ddimension);
 
 static PyMethodDef module_methods[] = {
   //{"calculate_", cmatrices_, METH_VARARGS, _docstring},
@@ -99,27 +101,45 @@ moduleinit(void)
 
 static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
 {
-  int Ng, force2D, force2Ddimension;
-  PyObject *image_obj, *mask_obj, *distances_obj;
-  PyArrayObject *image_arr, *mask_arr;
-  int Nd, Na;
+  int Ng, force2D, force2Ddimension, kernelRadius;
+  PyObject *image_obj, *mask_obj, *distances_obj, *voxels_obj;
+  PyArrayObject *image_arr, *mask_arr, *voxels_arr;
+  int Nd, Na, Nvox;
   int *size, *bb, *strides;
-  npy_intp dims[3];
+  npy_intp dims[4];
   PyArrayObject *glcm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *angles, *voxels;
   double *glcm;
-  int d;
+  int v;
+
+  // Initialize voxel-specific variables to default
+  Nvox = 1;
+  kernelRadius = 0;
+  voxels_obj = voxels_arr = voxels = NULL;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOiii", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension))
+  if (!PyArg_ParseTuple(args, "OOOiii|iO", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension, &kernelRadius, &voxels_obj))
     return NULL;
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, -1 if failed.
   if(try_parse_arrays(image_obj, mask_obj, &image_arr, &mask_arr, &Nd, &size, &strides, 0) < 0)
     return NULL;
+
+  // If provided, parse out the voxels array (indicating a voxel-based extraction is required)
+  // If not provided, voxels_obj will be NULL and stay NULL
+  if(try_parse_voxels_arr(voxels_obj, &voxels_arr, Nd, &Nvox, kernelRadius) < 0)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+
+    free(size);
+    free(strides);
+
+    return NULL;
+  }
 
   // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
   if(!force2D) force2Ddimension = -1;
@@ -128,6 +148,7 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
 
     free(size);
     free(strides);
@@ -137,15 +158,17 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
   angles = (int *)PyArray_DATA(angles_arr);
 
   // Initialize output array (elements not set)
-  dims[0] = Ng;
+  dims[0] = Nvox;
   dims[1] = Ng;
-  dims[2] = Na;
+  dims[2] = Ng;
+  dims[3] = Na;
 
   // Check that the maximum size of the array won't overflow the index variable (int32)
-  if (dims[0] * dims[1] * dims[2] > INT_MAX)
+  if (dims[0] * dims[1] * dims[2] * dims[3] > INT_MAX)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -155,11 +178,12 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  glcm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
+  glcm_arr = (PyArrayObject *)PyArray_SimpleNew(4, dims, NPY_DOUBLE);
   if (!glcm_arr)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -172,9 +196,11 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
   glcm = (double *)PyArray_DATA(glcm_arr);
+  if (voxels_arr)
+    voxels = (int *)PyArray_DATA(voxels_arr);
 
   // Set all elements to 0
-  memset(glcm, 0, sizeof *glcm * Ng * Ng * Na);
+  memset(glcm, 0, sizeof *glcm * Nvox * Ng * Ng * Na);
 
   // initialize bb
   bb = (int *)malloc(sizeof *bb * Nd * 2);
@@ -190,24 +216,27 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
 
     return PyErr_NoMemory();
   }
-  memset(bb, 0, sizeof *bb * Nd);
-  for (d = 0; d < Nd; d++)
-    bb[Nd + d] = size[d] - 1;
 
-  //Calculate GLCM
-  if (!calculate_glcm(image, mask, size, bb, strides, angles, Na, Nd, glcm, Ng))
+  //Calculate GLCM(s)
+  for (v = 0; v < Nvox; v++)
   {
-    Py_XDECREF(image_arr);
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(glcm_arr);
-    Py_XDECREF(angles_arr);
+    set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
 
-    free(size);
-    free(strides);
-    free(bb);
+    if (!calculate_glcm(image, mask, size, bb, strides, angles, Na, Nd, glcm + (v * Ng * Ng * Na), Ng))
+    {
+      Py_XDECREF(image_arr);
+      Py_XDECREF(mask_arr);
+      Py_XDECREF(glcm_arr);
+      Py_XDECREF(voxels_arr);
+      Py_XDECREF(angles_arr);
 
-    PyErr_SetString(PyExc_IndexError, "Calculation of GLCM Failed.");
-    return NULL;
+      free(size);
+      free(strides);
+      free(bb);
+
+      PyErr_SetString(PyExc_IndexError, "Calculation of GLCM Failed.");
+      return NULL;
+    }
   }
 
   // Clean up
@@ -223,29 +252,47 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
 
 static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
 {
-  int Ng, Ns, force2D, force2Ddimension;
-  PyObject *image_obj, *mask_obj;
-  PyArrayObject *image_arr, *mask_arr;
-  int Na, Nd;
+  int Ng, Ns, force2D, force2Ddimension, kernelRadius;
+  PyObject *image_obj, *mask_obj, *voxels_obj;
+  PyArrayObject *image_arr, *mask_arr, *voxels_arr;
+  int Na, Nd, Nvox, Nkernel;
   int *size, *bb, *strides;
-  npy_intp dims[2];
+  npy_intp dims[3];
   PyArrayObject *glszm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *angles, *voxels;
   int *tempData;
-  int maxRegion;
+  int region, maxRegion;
   double *glszm;
-  int d;
+  int v;
+
+  // Initialize voxel-specific variables to default
+  Nvox = 1;
+  kernelRadius = 0;
+  voxels_obj = voxels_arr = voxels = NULL;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOiiii", &image_obj, &mask_obj, &Ng, &Ns, &force2D, &force2Ddimension))
+  if (!PyArg_ParseTuple(args, "OOiiii|iO", &image_obj, &mask_obj, &Ng, &Ns, &force2D, &force2Ddimension, &kernelRadius, &voxels_obj))
     return NULL;
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, 1-3 if failed.
   if(try_parse_arrays(image_obj, mask_obj, &image_arr, &mask_arr, &Nd, &size, &strides, NPY_ARRAY_ENSURECOPY) < 0)
     return NULL;
+
+  // If provided, parse out the voxels array (indicating a voxel-based extraction is required)
+  // If not provided, voxels_obj will be NULL and stay NULL
+  if(try_parse_voxels_arr(voxels_obj, &voxels_arr, Nd, &Nvox, kernelRadius) < 0)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+
+    free(size);
+    free(strides);
+
+    return NULL;
+  }
 
   // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
   if(!force2D) force2Ddimension = -1;
@@ -254,22 +301,47 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
 
     free(size);
     free(strides);
     return NULL;
   }
 
+  // Get arrays in Ctype
   angles = (int *)PyArray_DATA(angles_arr);
+  image = (int *)PyArray_DATA(image_arr);
+  mask = (char *)PyArray_DATA(mask_arr);
+  if (voxels_arr)
+  {
+    // Voxel based extraction, check the maximum number of potential regions
+    // First, calculate max kernel size (Nkernel), equal to (2*kernelRadius + 1)^Nd (Nd - 1 if force2D is true)
+    v = Nd;
+    if (force2D) // Force2D is enabled, therefore subtract 1 from v (i.e. Nd - 1)
+      v--;
+    // For each dimension in which kernel size > 1, multiply Nkernel by the kernel size to get total kernel size.
+    Nkernel = 1;
+    for ( ; v > 0; v--)
+      Nkernel *= (kernelRadius * 2 + 1);
+
+    // If Nkernel size is smaller than Ns (No of segmented voxels), use Nkernel instead of Ns
+    // (conserves memory as less data is allocated for `tempData` and `regionStack`)
+    if (Ns > Nkernel)
+      Ns = Nkernel;
+
+    // Get the array of voxel indices
+    voxels = (int *)PyArray_DATA(voxels_arr);
+  }
 
   // Initialize temporary output array (elements not set)
   // add +1 to the size so in the case every voxel represents a separate region,
   // tempData still contains a -1 element at the end
-  tempData = (int *)malloc(sizeof *tempData * (2 * Ns + 1));
+  tempData = (int *)malloc(sizeof *tempData * Nvox * (2 * Ns + 1));
   if (!tempData)  // No memory allocated
   {
 	  Py_XDECREF(image_arr);
 	  Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
 	  free(size);
@@ -278,48 +350,53 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
     return PyErr_NoMemory();
   }
 
-  // Get arrays in Ctype
-  image = (int *)PyArray_DATA(image_arr);
-  mask = (char *)PyArray_DATA(mask_arr);
-
   // initialize bb
   bb = (int *)malloc(sizeof *bb * Nd * 2);
   if (!bb)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
-    Py_XDECREF(glszm_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
     free(strides);
+    free(tempData);
 
     return PyErr_NoMemory();
   }
-  memset(bb, 0, sizeof *bb * Nd);
-  for (d = 0; d < Nd; d++)
-    bb[Nd + d] = size[d] - 1;
 
   //Calculate GLSZM
-  maxRegion = calculate_glszm(image, mask, size, bb, strides, angles, Na, Nd, tempData, Ng, Ns);
-  if (maxRegion < 0) // Error occured
+  maxRegion = 0;
+  for (v = 0; v < Nvox; v++)
   {
-	  free(tempData);
-    Py_XDECREF(image_arr);
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(angles_arr);
+    set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
 
-    free(size);
-    free(strides);
-    free(bb);
+    region = calculate_glszm(image, mask, size, bb, strides, angles, Na, Nd, tempData + v * (2 * Ns + 1), Ng, Ns);
+    if (region < 0) // Error occured
+    {
+      free(tempData);
+      Py_XDECREF(image_arr);
+      Py_XDECREF(mask_arr);
+      Py_XDECREF(voxels_arr);
+      Py_XDECREF(angles_arr);
 
-    PyErr_SetString(PyExc_IndexError, "Calculation of GLSZM Failed.");
-    return NULL;
+      free(size);
+      free(strides);
+      free(bb);
+      free(tempData);
+
+      PyErr_SetString(PyExc_IndexError, "Calculation of GLSZM Failed.");
+      return NULL;
+    }
+    if (region > maxRegion)
+      maxRegion = region;
   }
 
   // Clean up image, mask and angles arrays (not needed anymore)
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
+  Py_XDECREF(voxels_arr);
   Py_XDECREF(angles_arr);
 
   free(size);
@@ -328,18 +405,19 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
 
   // Initialize output array (elements not set)
   if (maxRegion == 0) maxRegion = 1;
-  dims[0] = Ng;
-  dims[1] = maxRegion;
+  dims[0] = Nvox;
+  dims[1] = Ng;
+  dims[2] = maxRegion;
 
   // Check that the maximum size of the array won't overflow the index variable (int32)
-  if (dims[0] * dims[1] > INT_MAX)
+  if (dims[0] * dims[1] * dims[2] > INT_MAX)
   {
     free(tempData);
     PyErr_SetString(PyExc_RuntimeError, "Number of elements in GLSZM would overflow index variable! Increase bin width to prevent this error.");
     return NULL;
   }
 
-  glszm_arr = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  glszm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
   if (!glszm_arr)
   {
     free(tempData);
@@ -350,9 +428,9 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   glszm = (double *)PyArray_DATA(glszm_arr);
 
   // Set all elements to 0
-  memset(glszm, 0, sizeof *glszm * maxRegion * Ng);
+  memset(glszm, 0, sizeof *glszm * Nvox * maxRegion * Ng);
 
-  if (!fill_glszm(tempData, glszm, Ng, maxRegion))
+  if (!fill_glszm(tempData, glszm, Ng, maxRegion, Nvox))
   {
     free(tempData);
     Py_XDECREF(glszm_arr);
@@ -368,27 +446,45 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
 
 static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
 {
-  int Ng, Nr, force2D, force2Ddimension;
-  PyObject *image_obj, *mask_obj;
-  PyArrayObject *image_arr, *mask_arr;
-  int Nd, Na;
+  int Ng, Nr, force2D, force2Ddimension, kernelRadius;
+  PyObject *image_obj, *mask_obj, *voxels_obj;
+  PyArrayObject *image_arr, *mask_arr, *voxels_arr;
+  int Nd, Na, Nvox;
   int *size, *bb, *strides;
-  npy_intp dims[3];
+  npy_intp dims[4];
   PyArrayObject *glrlm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *angles, *voxels;
   double *glrlm;
-  int d;
+  int v;
+
+  // Initialize voxel-specific variables to default
+  Nvox = 1;
+  kernelRadius = 0;
+  voxels_obj = voxels_arr = voxels = NULL;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOiiii", &image_obj, &mask_obj, &Ng, &Nr, &force2D, &force2Ddimension))
+  if (!PyArg_ParseTuple(args, "OOiiii|iO", &image_obj, &mask_obj, &Ng, &Nr, &force2D, &force2Ddimension, &kernelRadius, &voxels_obj))
     return NULL;
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, -1 if failed.
   if(try_parse_arrays(image_obj, mask_obj, &image_arr, &mask_arr, &Nd, &size, &strides, 0) < 0)
     return NULL;
+
+  // If provided, parse out the voxels array (indicating a voxel-based extraction is required)
+  // If not provided, voxels_obj will be NULL and stay NULL
+  if(try_parse_voxels_arr(voxels_obj, &voxels_arr, Nd, &Nvox, kernelRadius) < 0)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+
+    free(size);
+    free(strides);
+
+    return NULL;
+  }
 
   // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
   if(!force2D) force2Ddimension = -1;
@@ -397,6 +493,7 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
 
     free(size);
     free(strides);
@@ -406,15 +503,17 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
   angles = (int *)PyArray_DATA(angles_arr);
 
   // Initialize output array (elements not set)
-  dims[0] = Ng;
-  dims[1] = Nr;
-  dims[2] = Na;
+  dims[0] = Nvox;
+  dims[1] = Ng;
+  dims[2] = Nr;
+  dims[3] = Na;
 
   // Check that the maximum size of the array won't overflow the index variable (int32)
-  if (dims[0] * dims[1] * dims[2] > INT_MAX)
+  if (dims[0] * dims[1] * dims[2] * dims[3] > INT_MAX)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -424,11 +523,12 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  glrlm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
+  glrlm_arr = (PyArrayObject *)PyArray_SimpleNew(4, dims, NPY_DOUBLE);
   if (!glrlm_arr)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -441,9 +541,11 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
   glrlm = (double *)PyArray_DATA(glrlm_arr);
+  if (voxels_arr)
+    voxels = (int *)PyArray_DATA(voxels_arr);
 
   // Set all elements to 0
-  memset(glrlm, 0, sizeof *glrlm * Ng * Nr * Na);
+  memset(glrlm, 0, sizeof *glrlm * Nvox * Ng * Nr * Na);
 
   // initialize bb
   bb = (int *)malloc(sizeof *bb * Nd * 2);
@@ -451,6 +553,7 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(glrlm_arr);
     Py_XDECREF(angles_arr);
 
@@ -459,29 +562,33 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
 
     return PyErr_NoMemory();
   }
-  memset(bb, 0, sizeof *bb * Nd);
-  for (d = 0; d < Nd; d++)
-    bb[Nd + d] = size[d] - 1;
 
   //Calculate GLRLM
-  if (!calculate_glrlm(image, mask, size, bb, strides, angles, Na, Nd, glrlm, Ng, Nr))
+  for (v = 0; v < Nvox; v++)
   {
-    Py_XDECREF(image_arr);
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(glrlm_arr);
-    Py_XDECREF(angles_arr);
+    set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
 
-    free(size);
-    free(strides);
-    free(bb);
+    if (!calculate_glrlm(image, mask, size, bb, strides, angles, Na, Nd, glrlm + v * Ng * Nr * Na, Ng, Nr))
+    {
+      Py_XDECREF(image_arr);
+      Py_XDECREF(mask_arr);
+      Py_XDECREF(voxels_arr);
+      Py_XDECREF(glrlm_arr);
+      Py_XDECREF(angles_arr);
 
-    PyErr_SetString(PyExc_IndexError, "Calculation of GLRLM Failed.");
-    return NULL;
+      free(size);
+      free(strides);
+      free(bb);
+
+      PyErr_SetString(PyExc_IndexError, "Calculation of GLRLM Failed.");
+      return NULL;
+    }
   }
 
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
+  Py_XDECREF(voxels_arr);
 
   free(size);
   free(strides);
@@ -492,27 +599,45 @@ static PyObject *cmatrices_calculate_glrlm(PyObject *self, PyObject *args)
 
 static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
 {
-  int Ng, force2D, force2Ddimension;
-  PyObject *image_obj, *mask_obj, *distances_obj;
-  PyArrayObject *image_arr, *mask_arr;
-  int Nd, Na;
+  int Ng, force2D, force2Ddimension, kernelRadius;
+  PyObject *image_obj, *mask_obj, *distances_obj, *voxels_obj;
+  PyArrayObject *image_arr, *mask_arr, *voxels_arr;
+  int Nd, Na, Nvox;
   int *size, *bb, *strides;
-  npy_intp dims[2];
+  npy_intp dims[3];
   PyArrayObject *ngtdm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *angles, *voxels;
   double *ngtdm;
-  int d;
+  int v;
+
+  // Initialize voxel-specific variables to default
+  Nvox = 1;
+  kernelRadius = 0;
+  voxels_obj = voxels_arr = voxels = NULL;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOiii", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension))
+  if (!PyArg_ParseTuple(args, "OOOiii|iO", &image_obj, &mask_obj, &distances_obj, &Ng, &force2D, &force2Ddimension, &kernelRadius, &voxels_obj))
     return NULL;
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, -1 if failed.
   if(try_parse_arrays(image_obj, mask_obj, &image_arr, &mask_arr, &Nd, &size, &strides, 0) < 0)
     return NULL;
+
+  // If provided, parse out the voxels array (indicating a voxel-based extraction is required)
+  // If not provided, voxels_obj will be NULL and stay NULL
+  if(try_parse_voxels_arr(voxels_obj, &voxels_arr, Nd, &Nvox, kernelRadius) < 0)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+
+    free(size);
+    free(strides);
+
+    return NULL;
+  }
 
   // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
   if(!force2D) force2Ddimension = -1;
@@ -521,6 +646,7 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
 
     free(size);
     free(strides);
@@ -530,14 +656,16 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   angles = (int *)PyArray_DATA(angles_arr);
 
   // Initialize output array (elements not set)
-  dims[0] = Ng;
-  dims[1] = 3;
+  dims[0] = Nvox;
+  dims[1] = Ng;
+  dims[2] = 3;
 
   // Check that the maximum size of the array won't overflow the index variable (int32)
-  if (dims[0] * dims[1] > INT_MAX)
+  if (dims[0] * dims[1] * dims[2] > INT_MAX)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -547,11 +675,12 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  ngtdm_arr = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  ngtdm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
   if (!ngtdm_arr)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -564,9 +693,11 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
   ngtdm = (double *)PyArray_DATA(ngtdm_arr);
+  if (voxels_arr)
+    voxels = (int *)PyArray_DATA(voxels_arr);
 
   // Set all elements to 0
-  memset(ngtdm, 0, sizeof *ngtdm * Ng * 3);
+  memset(ngtdm, 0, sizeof *ngtdm * Nvox * Ng * 3);
 
   // initialize bb
   bb = (int *)malloc(sizeof *bb * Nd * 2);
@@ -574,6 +705,7 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(ngtdm_arr);
     Py_XDECREF(angles_arr);
 
@@ -582,13 +714,15 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
 
     return PyErr_NoMemory();
   }
-  memset(bb, 0, sizeof *bb * Nd);
-  for (d = 0; d < Nd; d++)
-    bb[Nd + d] = size[d] - 1;
+
 
   //Calculate NGTDM
-  if (!calculate_ngtdm(image, mask, size, bb, strides, angles, Na, Nd, ngtdm, Ng))
+  for (v = 0; v < Nvox; v++)
   {
+    set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
+
+    if (!calculate_ngtdm(image, mask, size, bb, strides, angles, Na, Nd, ngtdm + v * Ng * 3, Ng))
+    {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
     Py_XDECREF(ngtdm_arr);
@@ -600,11 +734,13 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
 
     PyErr_SetString(PyExc_IndexError, "Calculation of NGTDM Failed.");
     return NULL;
+    }
   }
 
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
+  Py_XDECREF(voxels_arr);
   Py_XDECREF(angles_arr);
 
   free(size);
@@ -616,27 +752,45 @@ static PyObject *cmatrices_calculate_ngtdm(PyObject *self, PyObject *args)
 
 static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
 {
-  int Ng, alpha, force2D, force2Ddimension;
-  PyObject *image_obj, *mask_obj, *distances_obj;
-  PyArrayObject *image_arr, *mask_arr;
-  int Nd, Na;
+  int Ng, alpha, force2D, force2Ddimension, kernelRadius;
+  PyObject *image_obj, *mask_obj, *distances_obj, *voxels_obj;
+  PyArrayObject *image_arr, *mask_arr, *voxels_arr;
+  int Nd, Na, Nvox;
   int *size, *bb, *strides;
-  npy_intp dims[2];
+  npy_intp dims[3];
   PyArrayObject *gldm_arr, *angles_arr;
   int *image;
   char *mask;
-  int *angles;
+  int *angles, *voxels;
   double *gldm;
-  int d;
+  int v;
+
+  // Initialize voxel-specific variables to default
+  Nvox = 1;
+  kernelRadius = 0;
+  voxels_obj = voxels_arr = voxels = NULL;
 
   // Parse the input tuple
-  if (!PyArg_ParseTuple(args, "OOOiiii", &image_obj, &mask_obj, &distances_obj, &Ng, &alpha, &force2D, &force2Ddimension))
+  if (!PyArg_ParseTuple(args, "OOOiiii|iO", &image_obj, &mask_obj, &distances_obj, &Ng, &alpha, &force2D, &force2Ddimension, &kernelRadius, &voxels_obj))
     return NULL;
 
   // Check if array input is valid and extract sizes and strides of image and mask
   // Returns 0 if successful, -1 if failed.
   if(try_parse_arrays(image_obj, mask_obj, &image_arr, &mask_arr, &Nd, &size, &strides, 0) < 0)
     return NULL;
+
+  // If provided, parse out the voxels array (indicating a voxel-based extraction is required)
+  // If not provided, voxels_obj will be NULL and stay NULL
+  if(try_parse_voxels_arr(voxels_obj, &voxels_arr, Nd, &Nvox, kernelRadius) < 0)
+  {
+    Py_XDECREF(image_arr);
+    Py_XDECREF(mask_arr);
+
+    free(size);
+    free(strides);
+
+    return NULL;
+  }
 
   // If extraction is not forced 2D, ensure the dimension is set to a non-existent one (ensuring 3D angles when possible)
   if(!force2D) force2Ddimension = -1;
@@ -645,6 +799,7 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
 
     free(size);
     free(strides);
@@ -654,14 +809,16 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
   angles = (int *)PyArray_DATA(angles_arr);
 
   // Initialize output array (elements not set)
-  dims[0] = Ng;
-  dims[1] = Na * 2 + 1;  // No of possible dependency values = Na *2 + 1 (Na angels, 2 directions and +1 for no dependency)
+  dims[0] = Nvox;
+  dims[1] = Ng;
+  dims[2] = Na * 2 + 1;  // No of possible dependency values = Na *2 + 1 (Na angels, 2 directions and +1 for no dependency)
 
   // Check that the maximum size of the array won't overflow the index variable (int32)
-  if (dims[0] * dims[1] > INT_MAX)
+  if (dims[0] * dims[1] * dims[2] > INT_MAX)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -671,11 +828,12 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  gldm_arr = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  gldm_arr = (PyArrayObject *)PyArray_SimpleNew(3, dims, NPY_DOUBLE);
   if (!gldm_arr)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(angles_arr);
 
     free(size);
@@ -688,9 +846,11 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
   image = (int *)PyArray_DATA(image_arr);
   mask = (char *)PyArray_DATA(mask_arr);
   gldm = (double *)PyArray_DATA(gldm_arr);
+  if (voxels_arr)
+    voxels = (int *)PyArray_DATA(voxels_arr);
 
   // Set all elements to 0
-  memset(gldm, 0, sizeof *gldm * Ng * (Na * 2 + 1));
+  memset(gldm, 0, sizeof *gldm * Nvox * Ng * (Na * 2 + 1));
 
   // initialize bb
   bb = (int *)malloc(sizeof *bb * Nd * 2);
@@ -698,6 +858,7 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
   {
     Py_XDECREF(image_arr);
     Py_XDECREF(mask_arr);
+    Py_XDECREF(voxels_arr);
     Py_XDECREF(gldm_arr);
     Py_XDECREF(angles_arr);
 
@@ -706,29 +867,33 @@ static PyObject *cmatrices_calculate_gldm(PyObject *self, PyObject *args)
 
     return PyErr_NoMemory();
   }
-  memset(bb, 0, sizeof *bb * Nd);
-  for (d = 0; d < Nd; d++)
-    bb[Nd + d] = size[d] - 1;
 
   //Calculate GLDM
-  if (!calculate_gldm(image, mask, size, bb, strides, angles, Na, Nd, gldm, Ng, alpha))
+  for (v = 0; v < Nvox; v++)
   {
-    Py_XDECREF(image_arr);
-    Py_XDECREF(mask_arr);
-    Py_XDECREF(gldm_arr);
-    Py_XDECREF(angles_arr);
+    set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
 
-    free(size);
-    free(strides);
-    free(bb);
+    if (!calculate_gldm(image, mask, size, bb, strides, angles, Na, Nd, gldm + v * Ng * (Na * 2 + 1), Ng, alpha))
+    {
+      Py_XDECREF(image_arr);
+      Py_XDECREF(mask_arr);
+      Py_XDECREF(voxels_arr);
+      Py_XDECREF(gldm_arr);
+      Py_XDECREF(angles_arr);
 
-    PyErr_SetString(PyExc_IndexError, "Calculation of GLDM Failed.");
-    return NULL;
+      free(size);
+      free(strides);
+      free(bb);
+
+      PyErr_SetString(PyExc_IndexError, "Calculation of GLDM Failed.");
+      return NULL;
+    }
   }
 
   // Clean up
   Py_XDECREF(image_arr);
   Py_XDECREF(mask_arr);
+  Py_XDECREF(voxels_arr);
   Py_XDECREF(angles_arr);
 
   free(size);
@@ -940,4 +1105,66 @@ int try_parse_arrays(PyObject *image_obj, PyObject *mask_obj, PyArrayObject **im
     (*strides)[d] = (int)(PyArray_STRIDE(*image_arr, d) / PyArray_ITEMSIZE(*image_arr));
   }
   return 0;
+}
+
+int try_parse_voxels_arr(PyObject *voxels_obj, PyArrayObject **voxels_arr, int Nd, int *vox_cnt, int kernelRadius)
+{
+  if(voxels_obj && voxels_obj != Py_None)
+  {
+    if (kernelRadius <= 0)
+    {
+      PyErr_SetString(PyExc_RuntimeError, "Expecting kernelRadius > 0");
+      return -1;
+    }
+
+    voxels_arr = (PyArrayObject *)PyArray_FROM_OTF(voxels_obj, NPY_INT, NPY_ARRAY_FORCECAST | NPY_ARRAY_IN_ARRAY);
+    if(!voxels_arr)
+      return -1;
+
+    if(PyArray_NDIM(voxels_arr) != 2)
+    {
+      Py_XDECREF(voxels_arr);
+      PyErr_SetString(PyExc_RuntimeError, "Expecting voxel indices array to be 2-dimensional");
+      return -1;
+    }
+
+    if(PyArray_DIM(voxels_arr, 0) != Nd)
+    {
+      Py_XDECREF(voxels_arr);
+      PyErr_SetString(PyExc_RuntimeError, "Expecting voxel indices array to be 2-dimensional");
+      return -1;
+    }
+
+    *vox_cnt = PyArray_DIM(voxels_arr, 1);
+  }
+  return 0;
+}
+
+void set_bb(int v, int *bb, int *size, int *voxels, int Nd, int Nvox, int kernelRadius, int force2Ddimension)
+{
+  int d;
+  if (voxels)
+  {
+    for (d = 0; d < Nd; d++)
+    {
+      if (d == force2Ddimension)
+        bb[d] = bb[Nd + d] = voxels[d * Nvox + v];  // Do not define kernel in force2D dimension (i.e. size = 1)
+      else
+      {
+        bb[d] = voxels[d * Nvox + v] - kernelRadius;
+        if (bb[d] < 0)
+          bb[d] = 0;
+
+        bb[Nd + d] = voxels[d * Nvox + v] + kernelRadius;
+        if (bb[Nd + d] >= size[d])
+          bb[Nd + d] = size[d] - 1;
+      }
+    }
+  }
+  else
+  {
+    memset(bb, 0, sizeof *bb * Nd);
+    for (d = 0; d < Nd; d++)
+      bb[Nd + d] = size[d] - 1;
+  }
 }

--- a/radiomics/src/_cmatrices.c
+++ b/radiomics/src/_cmatrices.c
@@ -194,11 +194,6 @@ static PyObject *cmatrices_calculate_glcm(PyObject *self, PyObject *args)
   for (d = 0; d < Nd; d++)
     bb[Nd + d] = size[d] - 1;
 
-  printf("_BB");
-  for (d = 0; d < Nd; d++)
-    printf(", %i %i", bb[d], bb[Nd + d]);
-  printf("\n");
-
   //Calculate GLCM
   if (!calculate_glcm(image, mask, size, bb, strides, angles, Na, Nd, glcm, Ng))
   {

--- a/radiomics/src/_cmatrices.c
+++ b/radiomics/src/_cmatrices.c
@@ -372,7 +372,7 @@ static PyObject *cmatrices_calculate_glszm(PyObject *self, PyObject *args)
   {
     set_bb(v, bb, size, voxels, Nd, Nvox, kernelRadius, force2Ddimension);
 
-    region = calculate_glszm(image, mask, size, bb, strides, angles, Na, Nd, tempData + v * (2 * Ns + 1), Ng, Ns);
+    region = calculate_glszm(image, mask, size, bb, strides, angles, Na, Nd, tempData + v * (2 * Ns + 1), Ng, Ns, Nvox);
     if (region < 0) // Error occured
     {
       Py_XDECREF(image_arr);
@@ -1135,7 +1135,7 @@ int try_parse_voxels_arr(PyObject *voxels_obj, PyArrayObject **voxels_arr, int N
       return -1;
     }
 
-    *vox_cnt = PyArray_DIM(*voxels_arr, 1);
+    *vox_cnt = (int)PyArray_DIM(*voxels_arr, 1);
   }
   return 0;
 }

--- a/radiomics/src/cmatrices.c
+++ b/radiomics/src/cmatrices.c
@@ -1,7 +1,8 @@
 #include <stdlib.h>
+#include <Python.h>
 #include "cmatrices.h"
 
-int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng)
+int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng)
 {
   /* Calculate GLCM: Count the number of voxels with gray level i is neighboured by a voxel with gray level j in
   *  direction and distance specified by a. Returns an asymmetrical GLCM matrix for each angle/distance
@@ -16,21 +17,45 @@ int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles,
   // Output matrix variables
   int glcm_idx, glcm_idx_max = Ng * Ng * Na;  // Index and max index of the texture array
 
-  // Calculate size of image array
+  // Calculate size of image array, and set i at lower bound of bounding box
   Ni = size[0];
+  i = bb[0] * strides[0];
+  printf("BB: %i %i", bb[0], bb[Nd]);
   for (d = 1; d < Nd; d++)
+  {
+    i += bb[d] * strides[d];
     Ni *= size[d];
+    printf(", %i %i", bb[d], bb[Nd + d]);
+  }
+  printf("\n");
 
   // Loop over all voxels in the image
-  for (i = 0; i < Ni; i++)
+  for ( ; i < Ni; i++)
   {
+    // Calculate the current index in each dimension
+    for (d = Nd - 1; d > 0; d--)  // Iterate in reverse direction to handle strides from small to large
+    {
+      cur_idx[d] = (i % strides[d - 1]) / strides[d];
+      if (cur_idx[d] > bb[Nd + d])
+      {
+        // Set the i to the lower bound of the bounding box
+        // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+        // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+        i += (size[d] - cur_idx[d] + bb[d]) * strides[d];
+        cur_idx[d] = bb[d];  // Set cur_idx[d] to reflect the change to i
+      }
+    }
+
+    cur_idx[0] = i / strides[0];
+    if (cur_idx[0] > bb[Nd])
+      break; // Out-of-range in first dimension: end of bounding box reached
+
     if (mask[i])
     {
-      // Calculate the current index in each dimension
-      cur_idx[0] = i / strides[0];
+      printf("(%i", cur_idx[0]);
       for (d = 1; d < Nd; d++)
-        cur_idx[d] = (i % strides[d - 1]) / strides[d];
-
+        printf(", %i", cur_idx[d]);
+      printf(")");
       // Loop over all angles to get the neighbours
       for (a = 0; a < Na; a++)
       {
@@ -38,8 +63,9 @@ int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles,
         for (d = 0; d < Nd; d++)
         {
           // Check if the current offset does not go out-of-range
-          if (cur_idx[d] + angles[a * Nd + d] < 0 ||  cur_idx[d] + angles[a * Nd + d] >= size[d])
+          if (cur_idx[d] + angles[a * Nd + d] < bb[d] ||  cur_idx[d] + angles[a * Nd + d] > bb[Nd + d])
           {
+            printf(" b: a %i d %i j %i", a, d, cur_idx[d] + angles[a * Nd + d]);
             j = -1;  // Set to -1 to signal out-of-range below
             break;
           }
@@ -59,13 +85,14 @@ int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles,
           glcm[glcm_idx] ++;
         }
       }
+      printf("\n");
     }
   }
   free(cur_idx);
   return 1;
 }
 
-int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns)
+int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns)
 {
   /* Calculate the GLSZM: Count the number of connected zones with gray level i and size j in the ROI. Uses the angles
    * to find neighbours and pushes neighbours with the same gray level of the current zone onto a stack. Next, the last
@@ -96,13 +123,34 @@ int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles
 
   regionStack = (int *)malloc(sizeof *regionStack * Ns);
 
-  // Calculate size of image array
+  // Calculate size of image array, and set i at lower bound of bounding box
   Ni = size[0];
+  i = bb[0] * strides[0];
   for (d = 1; d < Nd; d++)
-    Ni *= size[d];
-
-  for (i = 0; i < Ni; i++)  // Loop over all the voxels in the image
   {
+    i += bb[d] * strides[d];
+    Ni *= size[d];
+  }
+
+  // Loop over all voxels in the image
+  for ( ; i < Ni; i++)
+  {
+    // Calculate the current index in each dimension
+    for (d = Nd - 1; d > 0; d--)  // Iterate in reverse direction to handle strides from small to large
+    {
+      cur_idx[d] = (i % strides[d - 1]) / strides[d];
+      if (cur_idx[d] > bb[Nd + d])
+      {
+        // Set the i to the lower bound of the bounding box
+        // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+        // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+        i += (size[d] - cur_idx[d] + bb[d]) * strides[d];
+      }
+    }
+
+    if (i / strides[0] > bb[Nd])
+      break; // Out-of-range in first dimension: end of bounding box reached
+
     // Check if the current voxel is part of the segmentation and unprocessed
     if (mask[i])
     {
@@ -123,7 +171,8 @@ int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles
         // Increment region size, as number of loops corresponds to number of voxels in current region
         region++;
 
-        // Calculate the current index in each dimension
+        // Calculate the current index in each dimension. No checks with bb are needed, as k is either
+        // equal to i (subject to bb checks) or to j (subject to bb checks)
         cur_idx[0] = k / strides[0];
         for (d = 1; d < Nd; d++)
           cur_idx[d] = (k % strides[d - 1]) / strides[d];
@@ -135,7 +184,7 @@ int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles
           for (d = 0; d < Nd; d++)
           {
             // Check if the current offset does not go out-of-range
-            if (cur_idx[d] + angles[a * Nd + d] < 0 ||  cur_idx[d] + angles[a * Nd + d] >= size[d])
+            if (cur_idx[d] + angles[a * Nd + d] < bb[d] ||  cur_idx[d] + angles[a * Nd + d] > bb[Nd + d])
             {
               j = -1;  // Set to -1 to signal out-of-range below
               break;
@@ -197,7 +246,7 @@ int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion)
   return 1;
 }
 
-int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr)
+int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr)
 {
   /* Calculate the GLRLM: Count the number of runs (=consecutive voxels with the same gray level) with gray level i and
    * run length j along angle a.
@@ -211,7 +260,7 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
    * GLRLM accordingly.
    */
   // Index and size variables of the image
-  int Ni;  // Size of the entire image array
+  int Ni, start_i;  // Size of the entire image array
   int i, j, a, d, md;  // Iterator variables (image, angles, dimensions)
   int cnt_mDim;  // Variable to hold the number of moving dims
   int multiElement;  // Variable to check whether the current angle only yields runs of length 1
@@ -226,10 +275,14 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
   int gl, rl, elements;
   int glrlm_idx, glrlm_idx_max = Ng * Nr * Na;  // Index and max index of the texture array
 
-  // Calculate size of image array
+  // Calculate size of image array, and calculate index of lower bound of bounding box (`start_i`)
   Ni = size[0];
+  start_i = bb[0] * strides[0];
   for (d = 1; d < Nd; d++)
+  {
+    start_i += bb[d] * strides[d];
     Ni *= size[d];
+  }
 
   for (a = 0; a < Na; a++)  // Iterate over angles to get the neighbours
   {
@@ -237,22 +290,41 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
     // First lookup and count the number of dimensions where the angle != 0 (i.e. "Moving dimensions")
     // Moreover, check if we need to start at 0 (angle > 0) or at the end (size[d] - 1, angle < 0)
     cnt_mDim = 0;
+    printf("Angle: ");
     for (d = 0; d < Nd; d++)
     {
+      printf("%i ", angles[a * 3 + d]);
       if (angles[a * Nd + d] != 0)
       {
         if (angles[a * Nd + d] > 0)
-          mDim_start[cnt_mDim] = 0;
+          mDim_start[cnt_mDim] = bb[d];
         else
-          mDim_start[cnt_mDim] = size[d] - 1;
+          mDim_start[cnt_mDim] = bb[Nd + d];
         mDims[cnt_mDim] = d;
         cnt_mDim++;
       }
     }
+    printf("\n");
 
-    // Then, iterate over the image (with the goal of getting all "start positions", i.e. from where we start the run
-    for (i = 0; i < Ni; i++)
+    // Then, iterate over the image (with the goal of getting all "start positions", i.e. from where we start the run)
+    for (i = start_i; i < Ni; i++)
     {
+      // Calculate the current index in each dimension and ensure it is within the bounding box.
+      for (d = Nd - 1; d > 0; d--)  // Iterate in reverse direction to handle strides from small to large
+      {
+        cur_idx = (i % strides[d - 1]) / strides[d];
+        if (cur_idx > bb[Nd + d])
+        {
+          // Set the i to the lower bound of the bounding box
+          // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+          // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+          i += (size[d] - cur_idx + bb[d]) * strides[d];
+        }
+      }
+
+      if (i / strides[0] > bb[Nd])
+        break; // Out-of-range in first dimension: end of bounding box reached
+
       // loop over moving dimensions to check if the current voxel is a valid starting voxel
       // a voxel is a starting voxel if it's index for a specific moving dimension matches the start index for
       // that dimension. If this is the case for ANY of the moving dimensions, the voxel is indeed a starting voxel
@@ -276,17 +348,49 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
       {
         // Oh oh, current voxel is not a starting position for any of the moving dimensions!
         // Skip to a valid index by ensure to fastest changing moving dimension is set to a valid start position.
-        // Because that dimension changes the fastest, it is the last one that changed from valid to invalid starting
-        // position and thereby guaranteed to be 1 if mDim_start = 0 and 0 if mDim_start = size[d] - 1.
-        // By adding (size[d] - 1) * stride we effectively either set the index for that dimension to 0 (and causing the
-        // next dimension to increase by 1) or to (size[d] - 1), respectively.
-        d = mDims[cnt_mDim - 1]; // Get the last moving dimension (i.e. the moving dimension with the smallest stride)
+        md = cnt_mDim - 1;
+        d = mDims[md]; // Get the last moving dimension (i.e. the moving dimension with the smallest stride)
 
-        i += (size[d] - 1) * strides[d]; // Skip the rest of the voxels in this moving dimension
+        printf("Skipping in moving dim %d! index ", d);
+        if (d == 0)
+          printf("%d -> ", i / strides[d]);
+        else
+          printf("%d -> ", (i % strides[d - 1]) / strides[d]);
 
-        if (i >= Ni)  // Check if this does not mean we've finished iterating over the entire image.
-          break;
+        // Advance i in the last moving dimension to a valid start position. Do this by calculating the difference
+        // between the current position (cur_idx, as the loop above ends with the last moving dimension) and the
+        // intended start position.
+        // Take the modulus with the size to ensure this change is always forward.
+        // Add size[d] to ensure the operation returns the modulus, not the remainder (% operator)
+        i += ((mDim_start[md] - cur_idx + size[d]) % size[d]) * strides[d]; // Skip the rest of the voxels in this moving dimension
+
+        if (d == 0)
+          printf("%d (s %i, i %i, size %i: +%i)", i / strides[d], mDim_start[md], cur_idx, size[d], (mDim_start[md] - cur_idx + size[d]) % size[d]);
+        else
+          printf("%d (s %i, i %i, size %i: +%i)", (i % strides[d - 1]) / strides[d], mDim_start[md], cur_idx, size[d], (mDim_start[md] - cur_idx + size[d]) % size[d]);
+
+        // Update all lower dimensions if necessary (ensuring it all stays within the bounding box)
+        d--;  // Don't handle the current dimension (=last moving dimension), we just did that above...
+        for ( ; d > 1 ; d--)
+        {
+          cur_idx = (i % strides[d - 1]) / strides[d];
+          if (cur_idx > bb[Nd + d])
+          {
+            // Set the i to the lower bound of the bounding box
+            // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+            // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+            i += (size[d] - cur_idx + bb[d]) * strides[d];
+          }
+        }
+
+        if (i / strides[0] > bb[Nd])
+          break; // Out-of-range in first dimension: end of bounding box reached
       }
+
+      printf("(%i", i / strides[0]);
+      for (d = 1; d < Nd; d++)
+        printf(", %i", (i % strides[d - 1]) / strides[d]);
+      printf(")\n");
 
       // Run Forest, Run! Start at the current index and advance using the angle until exiting the image.
       j = i;
@@ -345,8 +449,9 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
           else
             cur_idx = (j % strides[d - 1]) / strides[d];
           // Check if that is within the range [0, size[d])
-          if (cur_idx + angles[a * Nd + d] < 0 ||  cur_idx + angles[a * Nd + d] >= size[d])
+          if (cur_idx + angles[a * Nd + d] < bb[d] ||  cur_idx + angles[a * Nd + d] > bb[Nd + d])
           {
+            printf(" b: a %i d %i j %i", a, d, cur_idx[d] + angles[a * Nd + d]);
             j = -1;  // Set to -1 to signal out-of-range below
             break;
           }
@@ -384,7 +489,7 @@ int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles
   return 1;
 }
 
-int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng)
+int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng)
 {
   /* Calculate the NGTDM: For each voxel, calculate the absolute difference between the center voxel and the average of
    * its neighbours. Then, add this difference to a grand total (for the gray level i of the center voxel)
@@ -411,23 +516,40 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles
    * later on).
    */
 
-  // Calculate size of image array
+  // Calculate size of image array, and set i at lower bound of bounding box
   Ni = size[0];
+  i = bb[0] * strides[0];
   for (d = 1; d < Nd; d++)
+  {
+    i += bb[d] * strides[d];
     Ni *= size[d];
+  }
 
   // Loop over all voxels in the image
-  for (i = 0; i < Ni; i++)
+  for ( ; i < Ni; i++)
   {
+    // Calculate the current index in each dimension
+    for (d = Nd - 1; d > 0; d--)  // Iterate in reverse direction to handle strides from small to large
+    {
+      cur_idx[d] = (i % strides[d - 1]) / strides[d];
+      if (cur_idx[d] > bb[Nd + d])
+      {
+        // Set the i to the lower bound of the bounding box
+        // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+        // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+        i += (size[d] - cur_idx[d] + bb[d]) * strides[d];
+        cur_idx[d] = bb[d];  // Set cur_idx[d] to reflect the change to i
+      }
+    }
+
+    cur_idx[0] = i / strides[0];
+    if (cur_idx[0] > bb[Nd])
+      break; // Out-of-range in first dimension: end of bounding box reached
+
     if (mask[i])
     {
       count = 0;
       sum = 0;
-
-      // Calculate the current index in each dimension
-      cur_idx[0] = i / strides[0];
-      for (d = 1; d < Nd; d++)
-        cur_idx[d] = (i % strides[d - 1]) / strides[d];
 
       // Loop over all angles to get the neighbours
       for (a = 0; a < Na; a++)
@@ -436,7 +558,7 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles
         for (d = 0; d < Nd; d++)
         {
           // Check if the current offset does not go out-of-range
-          if (cur_idx[d] + angles[a * Nd + d] < 0 ||  cur_idx[d] + angles[a * Nd + d] >= size[d])
+          if (cur_idx[d] + angles[a * Nd + d] < bb[d] ||  cur_idx[d] + angles[a * Nd + d] > bb[Nd + d])
           {
             j = -1;  // Set to -1 to signal out-of-range below
             break;
@@ -475,7 +597,7 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles
   return 1;
 }
 
-int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha)
+int calculate_gldm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha)
 {
   /* Calculate GLDM: Count the number of voxels with gray level i, that have j dependent neighbours.
   *  A voxel is considered dependent if the absolute difference between the center voxel and the neighbour <= alpha
@@ -490,22 +612,39 @@ int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles,
   int dep, diff;
   int gldm_idx, gldm_idx_max = Ng * (Na * 2 + 1);  // Index and max index of the texture array
 
-  // Calculate size of image array
+  // Calculate size of image array, and set i at lower bound of bounding box
   Ni = size[0];
+  i = bb[0] * strides[0];
   for (d = 1; d < Nd; d++)
+  {
+    i += bb[d] * strides[d];
     Ni *= size[d];
+  }
 
   // Loop over all voxels in the image
-  for (i = 0; i < Ni; i++)
+  for ( ; i < Ni; i++)
   {
+    // Calculate the current index in each dimension
+    for (d = Nd - 1; d > 0; d--)  // Iterate in reverse direction to handle strides from small to large
+    {
+      cur_idx[d] = (i % strides[d - 1]) / strides[d];
+      if (cur_idx[d] > bb[Nd + d])
+      {
+        // Set the i to the lower bound of the bounding box
+        // size[d] - cur_idx[d] ensures an overflow, causing the index in current dimension to be 0
+        // Then, add bb[d] to ensure it is set to the lower bound of the bounding box
+        i += (size[d] - cur_idx[d] + bb[d]) * strides[d];
+        cur_idx[d] = bb[d];  // Set cur_idx[d] to reflect the change to i
+      }
+    }
+
+    cur_idx[0] = i / strides[0];
+    if (cur_idx[0] > bb[Nd])
+      break; // Out-of-range in first dimension: end of bounding box reached
+
     if (mask[i])
     {
       dep = 0;
-
-      // Calculate the current index in each dimension
-      cur_idx[0] = i / strides[0];
-      for (d = 1; d < Nd; d++)
-        cur_idx[d] = (i % strides[d - 1]) / strides[d];
 
       // Loop over all angles to get the neighbours
       for (a = 0; a < Na; a++)
@@ -514,7 +653,7 @@ int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles,
         for (d = 0; d < Nd; d++)
         {
           // Check if the current offset does not go out-of-range
-          if (cur_idx[d] + angles[a * Nd + d] < 0 ||  cur_idx[d] + angles[a * Nd + d] >= size[d])
+          if (cur_idx[d] + angles[a * Nd + d] < bb[d] ||  cur_idx[d] + angles[a * Nd + d] > bb[Nd + d])
           {
             j = -1;  // Set to -1 to signal out-of-range below
             break;

--- a/radiomics/src/cmatrices.c
+++ b/radiomics/src/cmatrices.c
@@ -218,21 +218,22 @@ int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, in
   return maxSize;
 }
 
-int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion)
+int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion, int Nvox)
 {
   /* This function fills the GLSZM using the zones described in the tempData. See calculate_glszm() for more details.
    */
-  int i = 0;
-  int glszm_idx, glszm_idx_max = Ng * maxRegion;  // Index and max index of the texture array
+  int v, i = 0;
+  int glszm_idx, glszm_idx_max = Nvox * Ng * maxRegion;  // Index and max index of the texture array
 
-  while(tempData[i * 2] > -1)
-  {
-    glszm_idx = (tempData[i * 2] - 1) * maxRegion + tempData[i * 2 + 1] - 1;
-    if (glszm_idx >= glszm_idx_max) return 0; // Index out of range
+  for (v = 0; v < Nvox; v++)
+    while(tempData[v * (Ng * 2 + 1) + i * 2] > -1)
+    {
+      glszm_idx = v * Ng * maxRegion + (tempData[v * (Ng * 2 + 1) + i * 2] - 1) * maxRegion + tempData[v * (Ng * 2 + 1) + i * 2 + 1] - 1;
+      if (glszm_idx >= glszm_idx_max) return 0; // Index out of range
 
-    glszm[glszm_idx]++;
-    i++;
-  }
+      glszm[glszm_idx]++;
+      i++;
+    }
   return 1;
 }
 

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,6 +1,6 @@
 int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng);
 int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns);
-int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
+int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion, int Nvox);
 int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr);
 int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng);
 int calculate_gldm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha);

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,5 +1,5 @@
 int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng);
-int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns);
+int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns, int Nvox);
 int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
 int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr);
 int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng);

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,8 +1,8 @@
-int calculate_glcm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng);
-int calculate_glszm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns);
+int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng);
+int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns);
 int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
-int calculate_glrlm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr);
-int calculate_ngtdm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng);
-int calculate_gldm(int *image, char *mask, int *size, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha);
+int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr);
+int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng);
+int calculate_gldm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha);
 int get_angle_count(int *size, int *distances, int Nd, int n_dist, char bidirectional, int force2Ddim);
 int build_angles(int *size, int *distances, int Nd, int n_dist, int force2Ddim, int Na, int *angles);

--- a/radiomics/src/cmatrices.h
+++ b/radiomics/src/cmatrices.h
@@ -1,6 +1,6 @@
 int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glcm, int Ng);
 int calculate_glszm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, int *tempData, int Ng, int Ns);
-int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion, int Nvox);
+int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion);
 int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *glrlm, int Ng, int Nr);
 int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *ngtdm, int Ng);
 int calculate_gldm(int *image, char *mask, int *size, int *bb, int *strides, int *angles, int Na, int Nd, double *gldm, int Ng, int alpha);


### PR DESCRIPTION
Builds on PR #463 by adding bounding-box constrained iteration in the C extensions.

This is then used to speed up and simplify voxel-based extraction:
- no need to iterate over the entire image, only the defined kernel
- no need to keep updating the mask array, kernel defined as combination of maskArray and bounding box in C (i.e. voxel index +/- kernelRadius in moving dimensions)
- allows vectorized feature calculation of multiple voxels