### PR TITLE
BUG: Force dType of discretized image array to int.

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -147,14 +147,15 @@ def binImage(parameterMatrix, parameterMatrixCoordinates=None, **kwargs):
   global logger
   logger.debug('Discretizing gray levels inside ROI')
 
+  discretizedParameterMatrix = numpy.zeros(parameterMatrix.shape, dtype='int')
   if parameterMatrixCoordinates is None:
     binEdges = getBinEdges(parameterMatrix.flatten(), **kwargs)
-    parameterMatrix = numpy.digitize(parameterMatrix, binEdges)
+    discretizedParameterMatrix = numpy.digitize(parameterMatrix, binEdges)
   else:
     binEdges = getBinEdges(parameterMatrix[parameterMatrixCoordinates], **kwargs)
-    parameterMatrix[parameterMatrixCoordinates] = numpy.digitize(parameterMatrix[parameterMatrixCoordinates], binEdges)
+    discretizedParameterMatrix[parameterMatrixCoordinates] = numpy.digitize(parameterMatrix[parameterMatrixCoordinates], binEdges)
 
-  return parameterMatrix, binEdges
+  return discretizedParameterMatrix, binEdges
 
 
 def checkMask(imageNode, maskNode, **kwargs):


### PR DESCRIPTION
If input image array has a dType with max-value smaller than the number of bins, an overflow can occur, causing invalid values and subsequent faillure of texture matrix calculation (e.g. values of '0' or negative values can be present, causing index errors).
To prevent this, ensure the output datatype is 'int', which has a large enough dynamic range to prevent overflow (if number of bins is larger than INT_MAX, the extraction will most likely fail anyway, due to size/memory issues).