### PR TITLE
Force emptyGrayLevels datatype to int

### DIFF
--- a/radiomics/glcm.py
+++ b/radiomics/glcm.py
@@ -143,7 +143,7 @@ class RadiomicsGLCM(base.RadiomicsFeaturesBase):
     # Delete rows and columns that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
-    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
+    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)), dtype=int)  # Gray values NOT present in ROI
 
     P_glcm = numpy.delete(P_glcm, emptyGrayLevels - 1, 1)
     P_glcm = numpy.delete(P_glcm, emptyGrayLevels - 1, 2)

--- a/radiomics/gldm.py
+++ b/radiomics/gldm.py
@@ -98,7 +98,7 @@ class RadiomicsGLDM(base.RadiomicsFeaturesBase):
     # Delete rows that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
-    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
+    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)), dtype=int)  # Gray values NOT present in ROI
 
     P_gldm = numpy.delete(P_gldm, emptyGrayLevels - 1, 1)
 

--- a/radiomics/glrlm.py
+++ b/radiomics/glrlm.py
@@ -111,7 +111,7 @@ class RadiomicsGLRLM(base.RadiomicsFeaturesBase):
     # Delete rows that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
-    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
+    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)), dtype=int)  # Gray values NOT present in ROI
 
     P_glrlm = numpy.delete(P_glrlm, emptyGrayLevels - 1, 1)
 

--- a/radiomics/glszm.py
+++ b/radiomics/glszm.py
@@ -95,7 +95,7 @@ class RadiomicsGLSZM(base.RadiomicsFeaturesBase):
     # Delete rows that specify gray levels not present in the ROI
     NgVector = range(1, Ng + 1)  # All possible gray values
     GrayLevels = self.coefficients['grayLevels']  # Gray values present in ROI
-    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)))  # Gray values NOT present in ROI
+    emptyGrayLevels = numpy.array(list(set(NgVector) - set(GrayLevels)), dtype=int)  # Gray values NOT present in ROI
 
     P_glszm = numpy.delete(P_glszm, emptyGrayLevels - 1, 1)
 


### PR DESCRIPTION
`emptyGrayLevels` is used as integer indices to remove the gray levels from the matrix. However, in linux python 3.6 and 3.7, the datatype defaults to `int64`, which is rejected by python when trying to use this as an index. Therefore, for the datatype of `emptyGrayLevels` to `int`, preventing the `IndexError`.

Fixes #592