### PR TITLE
BUG: Fail gracefully when grayvalue <= 0

### DIFF
--- a/radiomics/src/cmatrices.c
+++ b/radiomics/src/cmatrices.c
@@ -77,7 +77,7 @@ int calculate_glcm(int *image, char *mask, int *size, int *bb, int *strides, int
         if (j != i && mask[j])
         {
           glcm_idx = a + (image[j]-1) * Na + (image[i]-1) * Na * Ng;
-          if (glcm_idx >= glcm_idx_max)
+          if (image[i] <= 0 || image[j] <= 0 || glcm_idx >= glcm_idx_max)
           {
             free(cur_idx);
             return 0; // Index out of range
@@ -282,7 +282,7 @@ int fill_glszm(int *tempData, double *glszm, int Ng, int maxRegion)
   while(tempData[i * 2] > -1)
   {
     glszm_idx = (tempData[i * 2] - 1) * maxRegion + tempData[i * 2 + 1] - 1;
-    if (glszm_idx >= glszm_idx_max) return 0; // Index out of range
+    if (tempData[i * 2] <= 0 || glszm_idx >= glszm_idx_max) return 0; // Index out of range
 
     glszm[glszm_idx]++;
     i++;
@@ -452,7 +452,7 @@ int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, in
           else  // j is not part of the run, end current run and start new one
           {
             glrlm_idx = a + rl * Na + (gl - 1) * Na * Nr;
-            if (glrlm_idx >= glrlm_idx_max)
+            if (gl <= 0 || glrlm_idx >= glrlm_idx_max)
             {
               free(mDims);
               free(mDim_start);
@@ -467,7 +467,7 @@ int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, in
         else if (gl > -1)  // end current run
         {
           glrlm_idx = a + rl * Na + (gl - 1) * Na * Nr;
-          if (glrlm_idx >= glrlm_idx_max)
+          if (gl <= 0 || glrlm_idx >= glrlm_idx_max)
           {
             free(mDims);
             free(mDim_start);
@@ -506,7 +506,7 @@ int calculate_glrlm(int *image, char *mask, int *size, int *bb, int *strides, in
       if (gl > -1)  // end current run (this is the case when the last voxel of the run was included in the mask)
       {
         glrlm_idx = (gl - 1) * Na * Nr + rl * Na + a;
-        if (glrlm_idx >= glrlm_idx_max)
+        if (gl <= 0 || glrlm_idx >= glrlm_idx_max)
         {
           free(mDims);
           free(mDim_start);
@@ -637,7 +637,7 @@ int calculate_ngtdm(int *image, char *mask, int *size, int *bb, int *strides, in
         diff *= -1;  // Get absolute difference
 
       ngtdm_idx = (image[i]-1) * 3;
-      if (ngtdm_idx >= ngtdm_idx_max)
+      if (image[i] <= 0 || ngtdm_idx >= ngtdm_idx_max)
       {
         free(cur_idx);
         return 0; // Index out of range
@@ -734,7 +734,7 @@ int calculate_gldm(int *image, char *mask, int *size, int *bb, int *strides, int
         }
       }
       gldm_idx = dep + (image[i]-1) * (Na * 2 + 1);  // Row_idx (dep) + Col_idx (Gray level * Max dependency)
-      if (gldm_idx >= gldm_idx_max)
+      if (image[i] <= 0 || gldm_idx >= gldm_idx_max)
       {
         free(cur_idx);
         return 0; // Index out of range


### PR DESCRIPTION
"0" is an invalid value for gray level and causes an index error in the calculation of texture matrices (e.g. for GLSZM, correct index in matrix is calculated as (i, j) = (grayvalue - 1, region size), which in case of gray value 0 results in index -1, which is invalid).

In some case, this resulted in a graceful error where an IndexError is raised, but this is most likely because the datatype used for the index (`size_t`) does not allow for negative indices on some systems and therefore results in an overflow, which on the subsequent check is then indeed larger than the maximum allowed index (which is checked). In other cases, `size_t` datatype does allow for negative values and therefore passes the maximum index check and subsequently fails with a Process terminated.

Add an additional check to ensure the gray level is > 0, otherwise, fail the C Extension gracefully. Non-gray level properties (i.e. run length, zone size, dependence counts) are calculated in the C extension and ensured to be >= 0.