### PR TITLE
ENH: Add optional progress reporting for voxel-based extraction

### DIFF
--- a/radiomics/__init__.py
+++ b/radiomics/__init__.py
@@ -219,7 +219,7 @@ class _DummyProgressReporter(object):
   In this class, the __iter__ function redirects to the __iter__ function of the iterable passed at initialization.
   The __enter__ and __exit__ functions enable usage in a 'with' statement
   """
-  def __init__(self, iterable, desc=''):
+  def __init__(self, iterable=None, desc='', total=None):
     self.desc = desc  # A description is not required, but is provided by PyRadiomics
     self.iterable = iterable  # Iterable is required
 
@@ -231,6 +231,9 @@ class _DummyProgressReporter(object):
 
   def __exit__(self, exc_type, exc_value, tb):
     pass  # Nothing needs to be closed or handled, so just specify 'pass'
+
+  def update(self, n=1):
+    pass  # Nothing needs to be updated, so just specify 'pass'
 
 
 def getProgressReporter(*args, **kwargs):

--- a/radiomics/base.py
+++ b/radiomics/base.py
@@ -201,15 +201,17 @@ class RadiomicsFeaturesBase(object):
     if voxelBatch < 0:
       voxelBatch = voxel_count
     n_batches = numpy.ceil(float(voxel_count) / voxelBatch)
-    while voxel_batch_idx < voxel_count:
-      self.logger.debug('Calculating voxel batch no. %i/%i', int(voxel_batch_idx / voxelBatch) + 1, n_batches)
-      voxelCoords = self.labelledVoxelCoordinates[:, voxel_batch_idx:voxel_batch_idx + voxelBatch]
-      # Calculate the feature values for the current kernel
-      for success, featureName, featureValue in self._calculateFeatures(voxelCoords):
-        if success:
-          self.featureValues[featureName][tuple(voxelCoords)] = featureValue
+    with self.progressReporter(total=n_batches, desc='batch') as pbar:
+      while voxel_batch_idx < voxel_count:
+        self.logger.debug('Calculating voxel batch no. %i/%i', int(voxel_batch_idx / voxelBatch) + 1, n_batches)
+        voxelCoords = self.labelledVoxelCoordinates[:, voxel_batch_idx:voxel_batch_idx + voxelBatch]
+        # Calculate the feature values for the current kernel
+        for success, featureName, featureValue in self._calculateFeatures(voxelCoords):
+          if success:
+            self.featureValues[featureName][tuple(voxelCoords)] = featureValue
 
-      voxel_batch_idx += voxelBatch
+        voxel_batch_idx += voxelBatch
+        pbar.update(1)  # Update progress bar
 
     # Convert the output to simple ITK image objects
     for feature, enabled in six.iteritems(self.enabledFeatures):


### PR DESCRIPTION
Update base.py to add progress reporting when computing voxel batches. Uses `radiomics.getProgressReporter`, which should be set to something like `tqdm.tqdm` to work. Only shows progress bar when logging level is at least INFO (so not when WARNING or higher).