### PR TITLE
DOCS: Add force2D setting to example settings

### DIFF
--- a/examples/exampleSettings/MR_2D_extraction.yaml
+++ b/examples/exampleSettings/MR_2D_extraction.yaml
@@ -62,6 +62,7 @@ setting:
   # force2Ddimension setting is relative to the acquisition plane.
   # For example, the axial plane (0) corresponds to the acquisition plane (axial, sagittal or coronal) of the MRI volume.
   # Therefore, in most cases this setting should not be modified.
+  force2D: true
   force2Ddimension: 0
   
   # Image discretization:


### PR DESCRIPTION
In the example showing settings for 2D MR extraction, the setting `force2D` was missing. Add this setting with a value of `true` to ensure this example forces a 2D extraction.

@rcuocolo 