### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,14 @@ cache:
     - $HOME/downloads
 
 before_install:
-  - |
-      # Workaround the following error occuring because python installation is cached but gettext dependency is not
-      #   dyld: Library not loaded: /usr/local/opt/gettext/lib/libintl.8.dylib
-      #     Referenced from: /Users/travis/.pyenv/versions/3.7.2/bin/python
-      #     Reason: Incompatible library version: python requires version 11.0.0 or later, but libintl.8.dylib provides version 10.0.0
-      # See https://github.com/scikit-build/cmake-python-distributions/issues/112 and
-      # https://github.com/scikit-build/cmake-python-distributions/pull/113
-      brew install gettext
+  # Workaround the following error occuring because python installation is cached but gettext dependency is not
+  #   dyld: Library not loaded: /usr/local/opt/gettext/lib/libintl.8.dylib
+  #     Referenced from: /Users/travis/.pyenv/versions/3.7.2/bin/python
+  #     Reason: Incompatible library version: python requires version 11.0.0 or later, but libintl.8.dylib provides version 10.0.0
+  # See https://github.com/scikit-build/cmake-python-distributions/issues/112 and
+  # https://github.com/scikit-build/cmake-python-distributions/pull/113
+  - brew update
+  - brew install gettext
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
   - pip install scikit-ci scikit-ci-addons
   - ci_addons --install ../addons


### PR DESCRIPTION
Despite updates in #643, Travis CI still reports errors during testing.
This PR implements a further fix to the Travis CI Pipeline, by updating Brew before installing `gettext`.