### PR TITLE
BUG: Allow specification of full mask.

### DIFF
--- a/radiomics/imageoperations.py
+++ b/radiomics/imageoperations.py
@@ -45,7 +45,7 @@ def getMask(mask, **kwargs):
   mask = sitk.Cast(mask, sitk.sitkUInt32)
 
   labels = numpy.unique(sitk.GetArrayFromImage(mask))
-  if len(labels) == 1:
+  if len(labels) == 1 and labels[0] == 0:
     raise ValueError('No labels found in this mask (i.e. nothing is segmented)!')
   if label not in labels:
     raise ValueError('Label (%g) not present in mask. Choose from %s' % (label, labels[labels != 0]))


### PR DESCRIPTION
If a mask contains only a single label, a ValueError is raised stating no labels are found in the mask. However, this error should only be raised if the only label found is '0'.

Fixes #658 